### PR TITLE
Basic graph edits

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   "dependencies": {
     "@types/graphql": "^0.10.0",
     "lodash.isequal": "^4.5.0",
-    "lodash.isobject": "^3.0.2",
     "tslib": "^1.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@types/graphql": "^0.10.0",
+    "lodash.isobject": "^3.0.2",
     "tslib": "^1.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "eslint": "^4.2.0",
     "eslint-plugin-import": "nevir/eslint-plugin-import#randallreedjr-import-sort-order",
     "eslint-plugin-typescript": "^0.3.0",
+    "graphql": "^0.10.5",
+    "graphql-tag": "^2.4.2",
     "greenkeeper-lockfile": "^1.7.2",
     "jest": "^20.0.4",
     "jest-junit": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
   "devDependencies": {
     "@types/chai": "^4.0.1",
     "@types/chai-as-promised": "^0.0.31",
+    "@types/lodash": "^4.14.71",
+    "@types/lodash.isequal": "^4.5.1",
     "@types/node": "^8.0.16",
     "chai": "^4.1.0",
     "chai-as-promised": "^7.1.1",
@@ -56,6 +58,7 @@
   },
   "dependencies": {
     "@types/graphql": "^0.10.0",
+    "lodash.isequal": "^4.5.0",
     "lodash.isobject": "^3.0.2",
     "tslib": "^1.7.0"
   }

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -235,30 +235,6 @@ export class SnapshotEditor {
    * Returns the set of node ids that are newly orphaned by these edits.
    */
   private _mergeReferenceEdits(referenceEdits: ReferenceEdit[]): Set<NodeId> {
-    // The rough algorithm is as follows:
-    //
-    //   * For each entry in referenceEdits:
-    //
-    //     * If prevNodeId:
-    //
-    //       * Remove the inbound reference from _getOrCreateNew(prevNodeId).
-    //
-    //       * Remove the outbound reference from the source node.
-    //
-    //       * If there are no remaining inbound references and the node is not
-    //         a root, mark prevNodeId as orphaned.
-    //
-    //     * If nextNodeId:
-    //
-    //       * Insert the inbound reference to _getOrCreateNew(nextNodeId).
-    //
-    //       * Insert the outbound reference to the source node.
-    //
-    //       * If nextNodeId is present in the orphaned ids, remove it.
-    //
-    //     * Set the actual reference (to the next node) at path in containerId.
-    //
-    //   * Return the set of orphaned ids.
     for (const { containerId, path, prevNodeId, nextNodeId } of referenceEdits) {
       const target = nextNodeId ? this.get(nextNodeId) : null;
       this._setValue(containerId, path, target);

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -129,7 +129,7 @@ export class SnapshotEditor {
           // The payload is now referencing a new entity.  We want to update it,
           // but not until we've updated the values of our entities first.
           if (prevNodeId !== nextNodeId) {
-            referenceEdits.push({ containerId, path, prevNodeId, nextNodeId });
+            referenceEdits.push({ containerId, path: [...path], prevNodeId, nextNodeId });
           }
 
           // Either we have a new value to merge, or we're clearing a reference.

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -299,29 +299,19 @@ export class SnapshotEditor {
     const queue = Array.from(nodeIds);
     while (queue.length) {
       const nodeId = queue.pop() as NodeId;
+      const node = this.getSnapshot(nodeId);
+      if (!node) continue;
+
       this._newNodes[nodeId] = undefined;
       this._editedNodeIds.add(nodeId);
-    }
 
-    // The rough algorithm is as follows:
-    //
-    //   * Create a new set to track visited node ids.
-    //
-    //   * While there are ids in nodeIds:
-    //
-    //     * Pop an id off of nodeIds, and mark it visited.
-    //
-    //     * Set _newNodes[id] = undefined.
-    //
-    //     * For each of its outbound references:
-    //
-    //       * Remove the associated inbound reference.
-    //
-    //       * If they have no more inbound references and is not a root, push
-    //         them on the queue.
-    //
-    for (const nodeId of nodeIds) {
-      this._config.entityIdForNode(nodeId);
+      if (!node.outbound) continue;
+      for (const { id, path } of node.outbound) {
+        const reference = this._ensureNewSnapshot(id);
+        if (removeNodeReference('inbound', reference, nodeId, path)) {
+          queue.push(id);
+        }
+      }
     }
   }
 

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -318,7 +318,7 @@ export class SnapshotEditor {
   /**
    * Commits the transaction, returning a new immutable snapshot.
    */
-  commit(): { snapshot: GraphSnapshot, editedNodeIds: Set<NodeId> } {
+  commit(): EditedSnapshot {
     const snapshots: { [Key in NodeId]: NodeSnapshot } = { ...(this._parent as any)._values };
     for (const id in this._newNodes) {
       const newSnapshot = this._newNodes[id];

--- a/src/util/collection.ts
+++ b/src/util/collection.ts
@@ -1,7 +1,7 @@
 import { JsonScalar, PathPart } from '../primitive';
 
 /**
- *
+ * Adds values to a set, mutating it.
  */
 export function addToSet<T>(target: Set<T>, source: Iterable<T>): void {
   for (const value of source) {

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,2 +1,4 @@
 export * from './ast';
 export * from './collection';
+export * from './primitive';
+export * from './tree';

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,4 +1,5 @@
 export * from './ast';
 export * from './collection';
 export * from './primitive';
+export * from './references';
 export * from './tree';

--- a/src/util/primitive.ts
+++ b/src/util/primitive.ts
@@ -1,0 +1,9 @@
+import { scalar } from '../primitive';
+
+export function isScalar(value: any): value is scalar {
+  return typeof value !== 'object';
+}
+
+export function isObject(value: any): value is object {
+  return typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/util/references.ts
+++ b/src/util/references.ts
@@ -8,8 +8,10 @@ export type ReferenceType = 'inbound' | 'outbound';
 
 /**
  * Mutates a snapshot, removing an inbound reference from it.
+ *
+ * Returns whether all references were removed.
  */
-export function removeNodeReference(type: ReferenceType, snapshot: NodeSnapshot, id: NodeId, path: PathPart[]) {
+export function removeNodeReference(type: ReferenceType, snapshot: NodeSnapshot, id: NodeId, path: PathPart[]): boolean {
   const references = snapshot[type];
   if (!references) {
     throw new Error(`Inconsistent GraphSnapshot: Expected snapshot to have ${type} references`);
@@ -23,6 +25,8 @@ export function removeNodeReference(type: ReferenceType, snapshot: NodeSnapshot,
   if (!references.length) {
     (snapshot as any)[type] = undefined;
   }
+
+  return !references.length;
 }
 
 /**

--- a/src/util/references.ts
+++ b/src/util/references.ts
@@ -1,0 +1,38 @@
+import lodashIsEqual = require('lodash.isequal');
+
+import { NodeSnapshot } from '../NodeSnapshot';
+import { PathPart } from '../primitive';
+import { NodeId } from '../schema';
+
+export type ReferenceType = 'inbound' | 'outbound';
+
+/**
+ * Mutates a snapshot, removing an inbound reference from it.
+ */
+export function removeNodeReference(type: ReferenceType, snapshot: NodeSnapshot, id: NodeId, path: PathPart[]) {
+  const references = snapshot[type];
+  if (!references) {
+    throw new Error(`Inconsistent GraphSnapshot: Expected snapshot to have ${type} references`);
+  }
+
+  const fromIndex = references.findIndex((reference) => {
+    return lodashIsEqual(reference.id, id) && lodashIsEqual(reference.path, path);
+  });
+  references.splice(fromIndex, 1);
+
+  if (!references.length) {
+    (snapshot as any)[type] = undefined;
+  }
+}
+
+/**
+ * Mutates a snapshot, adding a new reference to it.
+ */
+export function addNodeReference(type: ReferenceType, snapshot: NodeSnapshot, id: NodeId, path: PathPart[]) {
+  let references = snapshot[type];
+  if (!references) {
+    references = (snapshot as any)[type] = [];
+  }
+
+  references.push({ id, path });
+}

--- a/src/util/tree.ts
+++ b/src/util/tree.ts
@@ -1,0 +1,17 @@
+import { PathPart } from '../primitive';
+
+export type Visitor = (
+  path: PathPart[],
+  payloadValue: any,
+  nodeValue: any,
+  // TODO: Walk for parameterized edges.
+) => void | boolean;
+
+/**
+ * Specialized node walker for payloads/nodes/selections when merging.
+ *
+ * TODO: May want something more generic.
+ */
+export function walkPayload(payload: any, node: any, visitor: Visitor) {
+
+}

--- a/src/util/tree.ts
+++ b/src/util/tree.ts
@@ -1,5 +1,26 @@
 import { PathPart } from '../primitive';
 
+/**
+ * Represents a node (of all values at the same location in their trees), used
+ * by the depth-first walk.
+ */
+class WalkNode {
+  constructor(
+    /** The value of the payload at this location in the walk. */
+    public readonly payload: any,
+    /** The value of the current node at this location in the walk. */
+    public readonly node: any,
+    /** The depth of the node (allows us to set the path correctly). */
+    public readonly depth: number,
+    /** The key/index of this node, relative to its parent. */
+    public readonly key?: PathPart,
+  ) {}
+}
+
+/**
+ * A function called when `walkPayload` visits a node in the payload, and any
+ * associated values from the node and references.
+ */
 export type Visitor = (
   path: PathPart[],
   payloadValue: any,
@@ -8,10 +29,57 @@ export type Visitor = (
 ) => void | boolean;
 
 /**
- * Specialized node walker for payloads/nodes/selections when merging.
+ * Walks a GraphQL payload that contains data to be merged into any existing
+ * data stored for the node it represents.
  *
- * TODO: May want something more generic.
+ * The walk is performed in a depth-first fashion, using `payload` as a guide.
+ * If `visitor` returns true, the walk will skip any children of the current
+ * node, effectively treating it as a leaf.
+ *
+ * All values from the node are walked following the same path.  Similarly,
+ * all values from `references` are walked, but they are only provided if a leaf
+ * (`EntityType`) is reached.  References skip over arrays, so that they apply
+ * to the values inside the (homogeneous) array.
  */
 export function walkPayload(payload: any, node: any, visitor: Visitor) {
+  // We perform a pretty standard depth-first traversal, with the addition of
+  // tracking the current path at each node.
+  const stack = [new WalkNode(payload, node, 0)];
+  const path = [] as PathPart[];
 
+  while (stack.length) {
+    const walkNode = stack.pop() as WalkNode;
+
+    // Don't visit the root.
+    if (walkNode.key !== undefined) {
+      path.splice(walkNode.depth - 1);
+      path.push(walkNode.key);
+      const skipChildren = visitor(path, walkNode.payload, walkNode.node);
+      if (skipChildren) continue;
+    }
+
+    // Note that in all cases, we push nodes onto the stack in _reverse_ order,
+    // so that we visit nodes in iteration order (the stack is FIFO).
+    const newDepth = walkNode.depth + 1;
+    if (Array.isArray(walkNode.payload)) {
+      for (let index = walkNode.payload.length - 1; index >= 0; index--) {
+        // Note that we DO NOT walk into `references` for array values; the
+        // references is blind to them, and continues to apply to all values
+        // contained within the array.
+        stack.push(new WalkNode(get(walkNode.payload, index), get(walkNode.node, index), newDepth, index));
+      }
+    } else if (walkNode.payload !== null && typeof walkNode.payload === 'object') {
+      const keys = Object.getOwnPropertyNames(walkNode.payload);
+      for (let index = keys.length - 1; index >= 0; index--) {
+        const key = keys[index];
+        stack.push(new WalkNode(get(walkNode.payload, key), get(walkNode.node, key), newDepth, key));
+      }
+    }
+
+  }
+}
+
+function get(value: any, key: PathPart) {
+  // Remember: arrays are typeof 'object', too.
+  return value !== null && typeof value === 'object' ? value[key] : undefined;
 }

--- a/test/helpers/graphql.ts
+++ b/test/helpers/graphql.ts
@@ -1,0 +1,15 @@
+import gql from 'graphql-tag';
+
+import { NodeId, Query, StaticNodeId } from '../../src/schema';
+import { getSelectionSetOrDie } from '../../src/util/ast';
+
+/**
+ * Constructs a Query from a gql document.
+ */
+export function query(gqlString: string, variables?: object, rootId?: NodeId): Query {
+  return {
+    rootId: rootId || StaticNodeId.QueryRoot,
+    selection: getSelectionSetOrDie(gql(gqlString)),
+    variables,
+  };
+}

--- a/test/unit/operations/write.ts
+++ b/test/unit/operations/write.ts
@@ -1,9 +1,8 @@
-import gql from 'graphql-tag';
-
 import { Configuration } from '../../../src/Configuration';
 import { GraphSnapshot } from '../../../src/GraphSnapshot';
 import { write } from '../../../src/operations/write';
 import { StaticNodeId } from '../../../src/schema';
+import { query } from '../../helpers/graphql';
 
 // These are really more like integration tests, given the underlying machinery.
 describe(`operations.write`, () => {
@@ -12,12 +11,12 @@ describe(`operations.write`, () => {
     entityIdForNode: (node: any) => node && node.id,
   };
 
-  const viewerQuery = gql`{
+  const viewerQuery = query(`{
     viewer {
       id
       name
     }
-  }`;
+  }`);
 
   const empty = new GraphSnapshot();
 

--- a/test/unit/operations/write.ts
+++ b/test/unit/operations/write.ts
@@ -1,0 +1,58 @@
+import gql from 'graphql-tag';
+
+import { Configuration } from '../../../src/Configuration';
+import { GraphSnapshot } from '../../../src/GraphSnapshot';
+import { write } from '../../../src/operations/write';
+import { StaticNodeId } from '../../../src/schema';
+
+// These are really more like integration tests, given the underlying machinery.
+describe(`operations.write`, () => {
+
+  const config: Configuration = {
+    entityIdForNode: (node: any) => node && node.id,
+  };
+
+  const viewerQuery = gql`{
+    viewer {
+      id
+      name
+    }
+  }`;
+
+  const empty = new GraphSnapshot();
+
+  describe(`end-to-end`, () => {
+
+    describe(`when writing a single root entity`, () => {
+
+      const { snapshot, editedNodeIds } = write(config, empty, viewerQuery, {
+        viewer: { id: 123, name: 'Gouda' },
+      });
+
+      it(`creates the query root, referencing the entity`, () => {
+        expect(snapshot.get(StaticNodeId.QueryRoot)).to.deep.eq({
+          viewer: { id: 123, name: 'Gouda' },
+        });
+      });
+
+      it(`indexes the entity`, () => {
+        expect(snapshot.get('123')).to.deep.eq({
+          id: 123, name: 'Gouda',
+        });
+      });
+
+      it(`directly references viewer from the query root`, () => {
+        const queryRoot = snapshot.get(StaticNodeId.QueryRoot);
+        const viewer = snapshot.get('123');
+        expect(queryRoot.viewer).to.eq(viewer);
+      });
+
+      it(`marks the entity as edited`, () => {
+        expect(editedNodeIds).to.have.members(['123']);
+      });
+
+    });
+
+  });
+
+});

--- a/test/unit/operations/write.ts
+++ b/test/unit/operations/write.ts
@@ -8,7 +8,7 @@ import { query } from '../../helpers/graphql';
 describe(`operations.write`, () => {
 
   const config: Configuration = {
-    entityIdForNode: (node: any) => node && node.id,
+    entityIdForNode: (node: any) => node && String(node.id),
   };
 
   const viewerQuery = query(`{
@@ -27,6 +27,7 @@ describe(`operations.write`, () => {
       const { snapshot, editedNodeIds } = write(config, empty, viewerQuery, {
         viewer: { id: 123, name: 'Gouda' },
       });
+      console.log(JSON.stringify(snapshot, null, 2));
 
       it(`creates the query root, referencing the entity`, () => {
         expect(snapshot.get(StaticNodeId.QueryRoot)).to.deep.eq({
@@ -47,7 +48,7 @@ describe(`operations.write`, () => {
       });
 
       it(`marks the entity as edited`, () => {
-        expect(editedNodeIds).to.have.members(['123']);
+        expect(Array.from(editedNodeIds)).to.have.members([StaticNodeId.QueryRoot, '123']);
       });
 
     });

--- a/test/unit/operations/write.ts
+++ b/test/unit/operations/write.ts
@@ -1,5 +1,6 @@
 import { Configuration } from '../../../src/Configuration';
 import { GraphSnapshot } from '../../../src/GraphSnapshot';
+import { NodeSnapshot } from '../../../src/NodeSnapshot';
 import { write } from '../../../src/operations/write';
 import { StaticNodeId } from '../../../src/schema';
 import { query } from '../../helpers/graphql';
@@ -69,6 +70,18 @@ describe(`operations.write`, () => {
       const queryRoot = snapshot.get(QueryRootId);
       const viewer = snapshot.get('123');
       expect(queryRoot.viewer).to.eq(viewer);
+    });
+
+    it(`records the outbound reference from the query root`, () => {
+      const queryRoot = snapshot.getSnapshot(QueryRootId) as NodeSnapshot;
+      expect(queryRoot.outbound).to.deep.eq([{ id: '123', path: ['viewer'] }]);
+      expect(queryRoot.inbound).to.eq(undefined);
+    });
+
+    it(`records the inbound reference from referenced entity`, () => {
+      const queryRoot = snapshot.getSnapshot('123') as NodeSnapshot;
+      expect(queryRoot.inbound).to.deep.eq([{ id: QueryRootId, path: ['viewer'] }]);
+      expect(queryRoot.outbound).to.eq(undefined);
     });
 
     it(`marks the entity and root as edited`, () => {

--- a/test/unit/operations/write.ts
+++ b/test/unit/operations/write.ts
@@ -313,7 +313,11 @@ describe(`operations.write`, () => {
   describe(`when orphaning a subgraph`, () => {
 
     const { snapshot: baseline } = write(config, empty, rootValuesQuery, {
-      foo: { id: 1, name: 'Foo' },
+      foo: {
+        id: 1,
+        name: 'Foo',
+        two: { id: 222 },
+      },
       bar: {
         id: 2,
         one: { id: 111 },
@@ -325,19 +329,28 @@ describe(`operations.write`, () => {
       },
     });
     const { snapshot, editedNodeIds } = write(config, baseline, rootValuesQuery, {
+      foo: { two: null },
       bar: null,
     });
 
     it(`doesn't mutate the previous versions`, () => {
       expect(baseline.get(QueryRootId)).to.deep.eq({
-        foo: { id: 1, name: 'Foo' },
+        foo: {
+          id: 1,
+          name: 'Foo',
+          two: { id: 222 },
+        },
         bar: {
           id: 2,
           one: { id: 111 },
           two: { id: 222 },
           three: {
             id: 333,
-            foo: { id: 1, name: 'Foo' },
+            foo: {
+              id: 1,
+              name: 'Foo',
+              two: { id: 222 },
+            },
           },
         },
       });
@@ -345,13 +358,13 @@ describe(`operations.write`, () => {
 
     it(`replaces the reference with null`, () => {
       expect(snapshot.get(QueryRootId)).to.deep.eq({
-        foo: { id: 1, name: 'Foo' },
+        foo: { id: 1, name: 'Foo', two: null },
         bar: null,
       });
     });
 
     it(`preserves nodes that only lost some of their inbound references`, () => {
-      expect(snapshot.get('1')).to.deep.eq({ id: 1, name: 'Foo' });
+      expect(snapshot.get('1')).to.deep.eq({ id: 1, name: 'Foo', two: null });
     });
 
     it(`updates outbound references`, () => {
@@ -360,7 +373,7 @@ describe(`operations.write`, () => {
     });
 
     it(`marks the container and all orphaned nodes as edited`, () => {
-      expect(Array.from(editedNodeIds)).to.have.members([QueryRootId, '2', '111', '222', '333']);
+      expect(Array.from(editedNodeIds)).to.have.members([QueryRootId, '1', '2', '111', '222', '333']);
     });
 
     it(`contains the correct nodes`, () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1046,6 +1046,16 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
+graphql-tag@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.4.2.tgz#6a63297d8522d03a2b72d26f1b239aab343840cd"
+
+graphql@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.npmjs.org/graphql/-/graphql-0.10.5.tgz#c9be17ca2bdfdbd134077ffd9bbaa48b8becd298"
+  dependencies:
+    iterall "^1.1.0"
+
 greenkeeper-lockfile@^1.7.2:
   version "1.7.2"
   resolved "https://registry.npmjs.org/greenkeeper-lockfile/-/greenkeeper-lockfile-1.7.2.tgz#1a038a0b7c8f7d4a726a714d0a56f439caad4b99"
@@ -1409,6 +1419,10 @@ istanbul-reports@^1.1.1:
   resolved "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz#042be5c89e175bc3f86523caab29c014e77fee4e"
   dependencies:
     handlebars "^4.0.3"
+
+iterall@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/iterall/-/iterall-1.1.1.tgz#f7f0af11e9a04ec6426260f5019d9fcca4d50214"
 
 jest-changed-files@^20.0.3:
   version "20.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1792,6 +1792,10 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
+lodash.isobject@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
+
 lodash.unescape@4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,10 +1806,6 @@ lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
-lodash.isobject@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
-
 lodash.unescape@4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,16 @@
   version "0.10.1"
   resolved "https://registry.npmjs.org/@types/graphql/-/graphql-0.10.1.tgz#3944e528bb3232e09cddb5364d75aba6342d068c"
 
+"@types/lodash.isequal@^4.5.1":
+  version "4.5.1"
+  resolved "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.1.tgz#154e051996f64a4a6262db8f4fd51a4b2a347ab4"
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*", "@types/lodash@^4.14.71":
+  version "4.14.71"
+  resolved "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.71.tgz#0dc383f78981216ac76e2f2c3afd998e0450e4c1"
+
 "@types/node@^8.0.16":
   version "8.0.16"
   resolved "https://registry.npmjs.org/@types/node/-/node-8.0.16.tgz#5aa51abd72621a0ce53fb86bccd76825ee1b4ca9"
@@ -1791,6 +1801,10 @@ locate-path@^2.0.0:
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
 lodash.isobject@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
This fills in the logic for writing to the cache, supporting _basic_ cases:

* Adding new nodes to a snapshot
* Editing values within existing nodes
* Normalized references between nodes

It adds _new_ behavior beyond the existing Apollo cache:

* Orphaned nodes are garbage collected.
* Payload values will merge with existing nodes, _even if they don't specify an `id`_. (may be controversial)

---

Next steps (not necessarily in order):

* Support for writing parameterized edges (and preprocessing selection sets to make that efficient)
* Support for reads (validating selection set, including parameterized edges)
* Wire up any missing pieces in order to support the new Apollo `Cache` API.