### PR TITLE
Parameterized edge map

### DIFF
--- a/scripts/test:unit:coverage.sh
+++ b/scripts/test:unit:coverage.sh
@@ -3,8 +3,17 @@ set -e
 
 source ./scripts/include/node.sh
 
-run test:unit -- --coverage
+OPTIONS=()
+if [[ "${CI}" == "" ]]; then
+  OPTIONS+=(
+    --coverageReporters html
+  )
+fi
 
-if [[ "${CI}" != "" ]]; then
+run test:unit -- --coverage "${OPTIONS[@]}"
+
+if [[ "${CI}" == "" ]]; then
+  open ./output/test:unit/index.html
+else
   codecov --file=./output/test:unit/lcov.info
 fi

--- a/src/apollo/util.ts
+++ b/src/apollo/util.ts
@@ -1,7 +1,6 @@
 import { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
 
 import { NodeId, Query, StaticNodeId } from '../schema';
-import { getSelectionSetOrDie } from '../util';
 
 /**
  * Builds a query.
@@ -9,7 +8,7 @@ import { getSelectionSetOrDie } from '../util';
 export function toQuery(document: DocumentNode, variables?: object, rootId?: NodeId): Query {
   return {
     rootId: rootId || StaticNodeId.QueryRoot,
-    selection: getSelectionSetOrDie(document),
+    document,
     variables,
   };
 }

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -1,6 +1,7 @@
 import { Configuration } from '../Configuration';
 import { GraphSnapshot } from '../GraphSnapshot';
 import { NodeId, Query } from '../schema';
+import { ParameterizedEdgeMap, parameterizedEdgesForOperation } from '../util';
 
 export interface QueryResult {
   /** The value of the root requested by a query. */
@@ -22,7 +23,7 @@ export function read(config: Configuration, query: Query, snapshot: GraphSnapsho
 export function read(config: Configuration, query: Query, snapshot: GraphSnapshot, includeNodeIds?: true) {
   let result = snapshot.get(query.rootId);
 
-  const parameterizedEdges = _parameterizedEdgesForSelection(query.document);
+  const parameterizedEdges = parameterizedEdgesForOperation(query.document);
   if (parameterizedEdges) {
     result = _overlayParameterizedValues(query, config, snapshot, parameterizedEdges, result);
   }
@@ -31,36 +32,6 @@ export function read(config: Configuration, query: Query, snapshot: GraphSnapsho
   const { complete, nodeIds } = _visitSelection(query, config, result, false);
 
   return { result, complete, nodeIds };
-}
-
-/**
- * A recursive map where the keys indicate the path to any edge in a result set
- * that contain a parameterized edge.
- */
-export interface ParameterizedEdgeMap {
-  [Key: string]: ParameterizedEdgeMap | true;
-}
-
-/**
- * Walks a selection set, identifying the path to all parameterized edges.
- */
-export function _parameterizedEdgesForSelection(selection: SelectionSetNode): ParameterizedEdgeMap | undefined {
-  // Rough algorithm is as follows:
-  //
-  //   * Return memoized value for `selection`, if present.
-  //
-  //   * Visit each node of `selection`, keeping track of the current path:
-  //
-  //     * If a FieldNode with arguments is encountered, deep set the path taken
-  //       to it in the edge map with a value of true.
-  //
-  //   * Return the edge map, if any.
-  //
-  // This has some room for improvement.  We can likely cache per-fragment, or
-  // per-node (particularly with some knowledge of the underlying schema).
-
-  // Random line to get ts/tslint to shut up.
-  return _parameterizedEdgesForSelection(selection);
 }
 
 /**

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -1,5 +1,3 @@
-import { SelectionSetNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
-
 import { Configuration } from '../Configuration';
 import { GraphSnapshot } from '../GraphSnapshot';
 import { NodeId, Query } from '../schema';
@@ -24,7 +22,7 @@ export function read(config: Configuration, query: Query, snapshot: GraphSnapsho
 export function read(config: Configuration, query: Query, snapshot: GraphSnapshot, includeNodeIds?: true) {
   let result = snapshot.get(query.rootId);
 
-  const parameterizedEdges = _parameterizedEdgesForSelection(query.selection);
+  const parameterizedEdges = _parameterizedEdgesForSelection(query.document);
   if (parameterizedEdges) {
     result = _overlayParameterizedValues(query, config, snapshot, parameterizedEdges, result);
   }
@@ -87,7 +85,7 @@ export function _overlayParameterizedValues<TResult>(
   //     * Determine the node id (if any) via config.entityIdForNode, and track
   //       it along side the current path.
   //
-  //     * If we've reached a value of `true` in the edge map:
+  //     * If we've reached a parameterized field node in the edge map:
   //
   //       * Determine the id of the parameterized edge (closest nodeId +
   //         parameters).

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,4 +1,4 @@
-import { SelectionSetNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
+import { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
 
 /**
  * Change ids track diffs to the store that may eventually be rolled back.
@@ -33,8 +33,8 @@ export enum StaticNodeId {
 export interface Query {
   /** The id of the node to begin the query at. */
   readonly rootId: NodeId;
-  /** The properties within the cache that the query is concerned with. */
-  readonly selection: SelectionSetNode;
+  /** A parsed GraphQL document, declaring an operation to execute. */
+  readonly document: DocumentNode;
   /** Any variables used by parameterized edges within the selection set. */
   readonly variables?: object;
 }

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -8,7 +8,7 @@ import { // eslint-disable-line import/no-extraneous-dependencies, import/no-unr
   ValueNode,
 } from 'graphql';
 
-import { JsonValue } from '../primitive';
+import { JsonScalar } from '../primitive';
 
 /**
  * Extracts the query operation from `document`.
@@ -62,12 +62,20 @@ export class VariableArgument {
 }
 
 /**
+ * A value that can be expressed as an argument of a parameterized edge.
+ */
+export type EdgeArgumentScalar = JsonScalar | VariableArgument;
+export interface EdgeArgumentArray extends Array<EdgeArgument> {}
+export interface EdgeArgumentObject { [Key: string]: EdgeArgument }
+export type EdgeArgument = EdgeArgumentScalar | EdgeArgumentArray | EdgeArgumentObject;
+
+/**
  * Represents a parameterized edge (within an edge map).
  */
 export class ParameterizedEdge {
   constructor(
     /** The map of arguments and their static or variable values. */
-    public readonly args: { [Key: string]: JsonValue | VariableArgument },
+    public readonly args: EdgeArgumentObject,
     /** Any child edge maps. */
     public readonly children?: ParameterizedEdgeMap,
   ) {}

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -25,22 +25,6 @@ export function getOperationOrDie(document: DocumentNode): OperationDefinitionNo
   return operations[0];
 }
 
-/**
- * Extracts the selection set from `document`.
- */
-export function getSelectionSetOrDie(document: DocumentNode): SelectionSetNode {
-  if (document.definitions.length !== 1) {
-    throw new Error(`Ambiguous document: Expected a single definition`);
-  }
-  const definition = document.definitions[0];
-  if (!('selectionSet' in definition)) {
-    // TODO: Include the document or source with the error, as data.
-    throw new Error(`Expected to find a selection set within GQL document, but found none`);
-  }
-
-  return (definition as any).selectionSet as SelectionSetNode;
-}
-
 export interface FragmentMap {
   [Key: string]: FragmentDefinitionNode,
 }

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -72,6 +72,7 @@ export interface ParameterizedEdgeMap {
  */
 export class VariableArgument {
   constructor(
+    /** The name of the variable. */
     public readonly name: string,
   ) {}
 }
@@ -102,7 +103,7 @@ export function parameterizedEdgesForOperation(document: DocumentNode): Paramete
 /**
  * Recursively builds an edge map.
  *
- * TODO: Support for directives.
+ * TODO: Support for directives (maybe?).
  */
 function _buildParameterizedEdgeMap(fragments: FragmentMap, selectionSet?: SelectionSetNode): ParameterizedEdgeMap | undefined {
   if (!selectionSet) return undefined;

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -1,4 +1,4 @@
-import {  // eslint-disable-line
+import { // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
   ArgumentNode,
   DocumentNode,
   FieldNode,

--- a/test/env/unit.ts
+++ b/test/env/unit.ts
@@ -1,1 +1,5 @@
+import { disableFragmentWarnings } from 'graphql-tag';
+
 import './base';
+
+disableFragmentWarnings();

--- a/test/helpers/graphql.ts
+++ b/test/helpers/graphql.ts
@@ -1,7 +1,6 @@
 import gql from 'graphql-tag';
 
 import { NodeId, Query, StaticNodeId } from '../../src/schema';
-import { getSelectionSetOrDie } from '../../src/util/ast';
 
 /**
  * Constructs a Query from a gql document.
@@ -9,7 +8,7 @@ import { getSelectionSetOrDie } from '../../src/util/ast';
 export function query(gqlString: string, variables?: object, rootId?: NodeId): Query {
   return {
     rootId: rootId || StaticNodeId.QueryRoot,
-    selection: getSelectionSetOrDie(gql(gqlString)),
+    document: gql(gqlString),
     variables,
   };
 }

--- a/test/helpers/index.ts
+++ b/test/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './graphql';

--- a/test/unit/operations/write.ts
+++ b/test/unit/operations/write.ts
@@ -3,7 +3,7 @@ import { GraphSnapshot } from '../../../src/GraphSnapshot';
 import { NodeSnapshot } from '../../../src/NodeSnapshot';
 import { write } from '../../../src/operations/write';
 import { StaticNodeId } from '../../../src/schema';
-import { query } from '../../helpers/graphql';
+import { query } from '../../helpers';
 
 const { QueryRoot: QueryRootId } = StaticNodeId;
 

--- a/test/unit/operations/write.ts
+++ b/test/unit/operations/write.ts
@@ -460,4 +460,38 @@ describe(`operations.write`, () => {
 
   });
 
+  describe(`parameterized edges`, () => {
+
+    describe(`new nodes with variables`, () => {
+
+      const parameterizedQuery = query(`query getAFoo($id: ID!) {
+        foo(id: $id, withExtra: true) {
+          id name extra
+        }
+      }`, { id: 1 });
+
+      const { snapshot, editedNodeIds } = write(config, empty, parameterizedQuery, {
+        foo: {
+          id: 1,
+          name: 'Foo',
+          extra: false,
+        },
+      });
+
+      it(`writes the referenced node`, () => {
+        expect(snapshot.get('1')).to.deep.eq({ id: 1, name: 'Foo', extra: false });
+      });
+
+      it(`does not expose the parameterized edge directly from its container`, () => {
+        expect(snapshot.get(QueryRootId)).to.deep.eq({});
+      });
+
+      it(`marks `, () => {
+        expect(Array.from(editedNodeIds)).to.have.members([QueryRootId, '1']);
+      });
+
+    });
+
+  });
+
 });

--- a/test/unit/operations/write.ts
+++ b/test/unit/operations/write.ts
@@ -460,7 +460,7 @@ describe(`operations.write`, () => {
 
   });
 
-  describe(`parameterized edges`, () => {
+  describe.skip(`parameterized edges`, () => {
 
     describe(`new nodes with variables`, () => {
 

--- a/test/unit/util/ast.ts
+++ b/test/unit/util/ast.ts
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag';
 
-import { ParameterizedEdge, parameterizedEdgesForOperation } from '../../../src/util';
+import { ParameterizedEdge, VariableArgument, parameterizedEdgesForOperation } from '../../../src/util';
 
 describe(`util.ast`, () => {
 
@@ -106,6 +106,35 @@ describe(`util.ast`, () => {
     });
 
     describe(`with variables`, () => {
+
+      it(`creates placeholder args for variables`, () => {
+        const map = parameterizedEdgesForOperation(gql`
+          query get($id: ID!) {
+            foo(id: $id) { a b c }
+          }
+        `);
+        expect(map).to.deep.eq({
+          foo: new ParameterizedEdge({
+            id: new VariableArgument('id'),
+          }),
+        });
+      });
+
+      it(`handles a mix of variables and static values`, () => {
+        const map = parameterizedEdgesForOperation(gql`
+          query get($id: ID!, $val: String) {
+            foo(id: $id, foo: "asdf", bar: $id, baz: $val) { a b c }
+          }
+        `);
+        expect(map).to.deep.eq({
+          foo: new ParameterizedEdge({
+            id: new VariableArgument('id'),
+            foo: 'asdf',
+            bar: new VariableArgument('id'),
+            baz: new VariableArgument('val'),
+          }),
+        });
+      });
 
     });
 

--- a/test/unit/util/ast.ts
+++ b/test/unit/util/ast.ts
@@ -1,0 +1,114 @@
+import gql from 'graphql-tag';
+
+import { ParameterizedEdge, parameterizedEdgesForOperation } from '../../../src/util';
+
+describe(`util.ast`, () => {
+
+  describe(`parameterizedEdgesForSelection`, () => {
+
+    describe(`with no parameterized edges`, () => {
+
+      it(`returns undefined for selections sets with no parameterized edges`, () => {
+        const map = parameterizedEdgesForOperation(gql`{ foo bar }`);
+        expect(map).to.eq(undefined);
+      });
+
+      it(`handles fragments without parameterized edges`, () => {
+        const map = parameterizedEdgesForOperation(gql`
+          query foo { ...bar }
+
+          fragment bar on Foo {
+            stuff { ...things }
+          }
+
+          fragment things on Stuff { a b c }
+        `);
+        expect(map).to.eq(undefined);
+      });
+
+    });
+
+    describe(`with static arguments`, () => {
+
+      it(`parses top level edges`, () => {
+        const map = parameterizedEdgesForOperation(gql`{ foo(id:123) { a b } }`);
+        expect(map).to.deep.eq({
+          foo: new ParameterizedEdge({ id: 123 }),
+        });
+      });
+
+      it(`parses queries with sibling edges`, () => {
+        const map = parameterizedEdgesForOperation(gql`{ foo(id: 123) { a b } bar(id: "asdf") { a b } }`);
+        expect(map).to.deep.eq({
+          foo: new ParameterizedEdge({ id: 123 }),
+          bar: new ParameterizedEdge({ id: 'asdf' }),
+        });
+      });
+
+      it(`handles nested edges`, () => {
+        const map = parameterizedEdgesForOperation(gql`{
+          foo(id: 123) {
+            bar(asdf: "fdsa") {
+              baz(one: true, two: null) { a b c }
+            }
+          }
+        }`);
+        expect(map).to.deep.eq({
+          foo: new ParameterizedEdge({ id: 123 }, {
+            bar: new ParameterizedEdge({ asdf: 'fdsa' }, {
+              baz: new ParameterizedEdge({ one: true, two: null }),
+            }),
+          }),
+        });
+      });
+
+      it(`properly constructs deeply nested paths`, () => {
+        const map = parameterizedEdgesForOperation(gql`{
+          foo {
+            fizz {
+              buzz {
+                moo(val: 1.234) { a b c }
+              }
+            }
+          }
+        }`);
+        expect(map).to.deep.eq({
+          foo: {
+            fizz: {
+              buzz: {
+                moo: new ParameterizedEdge({ val: 1.234 }),
+              },
+            },
+          },
+        });
+      });
+
+      it(`handles edges declared via fragment spreads`, () => {
+        const map = parameterizedEdgesForOperation(gql`
+          fragment bar on Foo {
+            stuff { ...things }
+          }
+
+          query foo { ...bar }
+
+          fragment things on Stuff {
+            things(count: 5) { id value }
+          }
+        `);
+
+        expect(map).to.deep.eq({
+          stuff: {
+            things: new ParameterizedEdge({ count: 5 }),
+          },
+        });
+      });
+
+    });
+
+    describe(`with variables`, () => {
+
+    });
+
+  });
+
+});

--- a/test/unit/util/ast.ts
+++ b/test/unit/util/ast.ts
@@ -103,6 +103,47 @@ describe(`util.ast`, () => {
         });
       });
 
+      it(`supports all types of variables`, () => {
+        const map = parameterizedEdgesForOperation(gql`
+          query typetastic($variable: Custom) {
+            foo(
+              variable: $variable,
+              null: null,
+              int: 123,
+              float: 1.23,
+              string: "foo",
+              list: [$variable, null, 123, 1.23, "foo", { a: "b" }],
+              object: {
+                variable: $variable,
+                null: null,
+                int: 123,
+                float: 1.23,
+                string: "foo",
+                list: [$variable, null, 123, 1.23, "foo", { a: "b" }],
+              },
+            ) { a }
+          }
+        `);
+        expect(map).to.deep.eq({
+          foo: new ParameterizedEdge({
+            variable: new VariableArgument('variable'),
+            null: null,
+            int: 123,
+            float: 1.23,
+            string: 'foo',
+            list: [new VariableArgument('variable'), null, 123, 1.23, 'foo', { a: 'b' }],
+            object: {
+              variable: new VariableArgument('variable'),
+              null: null,
+              int: 123,
+              float: 1.23,
+              string: 'foo',
+              list: [new VariableArgument('variable'), null, 123, 1.23, 'foo', { a: 'b' }],
+            },
+          }),
+        });
+      });
+
     });
 
     describe(`with variables`, () => {


### PR DESCRIPTION
Builder that parses a GraphQL document, turning it into an lookup map to determine which fields of a query are parameterized edges.

This'll be used by `SnapshotEditor` when persisting results from queries with parameterized edges, as well as by `read` when determining which nodes need to be made into views on top of underlying data.

This also refactored `Query` to pass around a complete GraphQL document, rather than just the selection set.  We need the document to look up fragment definitions.

Note that there is a lot of room for improvement here (e.g. memoizing by query, and/or by fragment)