### PR TITLE
Write support for parameterized values

### DIFF
--- a/src/NodeSnapshot.ts
+++ b/src/NodeSnapshot.ts
@@ -30,7 +30,7 @@ export namespace NodeSnapshot {
     /**
      * The path (object/array keys) within the node to the reference.
      */
-    path: PathPart[],
+    path?: PathPart[],
   }
 
   // Specializations.

--- a/src/NodeSnapshot.ts
+++ b/src/NodeSnapshot.ts
@@ -7,7 +7,7 @@ import { NodeId } from './schema';
 export class NodeSnapshot {
   constructor(
     /** A reference to the node this snapshot is about. */
-    readonly node: any,
+    readonly node?: any,
     /** Other node snapshots that point to this one. */
     readonly inbound?: NodeSnapshot.NodeReference[],
     /** The node snapshots that this one points to. */

--- a/src/NodeSnapshot.ts
+++ b/src/NodeSnapshot.ts
@@ -31,6 +31,9 @@ export namespace NodeSnapshot {
 
     /**
      * The path (object/array keys) within the node to the reference.
+     *
+     * If the path is omitted, this reference is used purely for garbage
+     * collection, but is not walked when regenerating node references.
      */
     path?: PathPart[],
   }

--- a/src/NodeSnapshot.ts
+++ b/src/NodeSnapshot.ts
@@ -4,13 +4,15 @@ import { NodeId } from './schema';
 /**
  * Bookkeeping metadata and a reference to a unique node in the cached graph.
  */
-export interface NodeSnapshot {
-  /** A reference to the node this snapshot is about. */
-  readonly node: any,
-  /** Other node snapshots that point to this one. */
-  readonly inbound?: NodeSnapshot.NodeReference[];
-  /** The node snapshots that this one points to. */
-  readonly outbound?: NodeSnapshot.NodeReference[];
+export class NodeSnapshot {
+  constructor(
+    /** A reference to the node this snapshot is about. */
+    readonly node: any,
+    /** Other node snapshots that point to this one. */
+    readonly inbound?: NodeSnapshot.NodeReference[],
+    /** The node snapshots that this one points to. */
+    readonly outbound?: NodeSnapshot.NodeReference[],
+  ) {}
 }
 
 export namespace NodeSnapshot {
@@ -31,83 +33,6 @@ export namespace NodeSnapshot {
      * The path (object/array keys) within the node to the reference.
      */
     path?: PathPart[],
-  }
-
-  // Specializations.
-
-  /**
-   * A node snapshot that tracks one of the application's domain (business)
-   * objects.
-   */
-  export class Entity implements NodeSnapshot {
-
-    constructor(
-      /**
-       * A reference to the node this snapshot is about.
-       */
-      public readonly node: object,
-
-      /**
-       * Other node snapshots that point to this one.
-       */
-      public readonly inbound?: NodeReference[],
-
-      /**
-       * The node snapshots that this one points to.
-       */
-      readonly outbound?: NodeSnapshot.NodeReference[],
-
-      /**
-       * Whether this node is considered a root of the graph.
-       *
-       * Roots, and the nodes they transitively reference, are not garbage
-       * collected.
-       */
-      public readonly root?: true,
-    ) {}
-
-  }
-
-  /**
-   * A node snapshot that tracks the node of a parameterized edge, relative to
-   * a domain object.
-   *
-   * It is expected that the
-   */
-  export class ParameterizedValue implements NodeSnapshot {
-
-    constructor(
-      /**
-       * The node of a parameterized edge within a domain object.
-       */
-      public readonly node: any,
-
-      /**
-       * The specific arguments associated with the node.
-       *
-       * TODO: Do we need this?  If not, consider folding the types together.
-       *
-       * But let's call 'em "parameters", just to reduce the number of terms you
-       * need to juggle…
-       */
-      public readonly parameters: object,
-
-      /**
-       * There is only ever one inbound edge for the parameterized node: the
-       * domain object that contains it.
-       *
-       * This reference is used to identify where in the domain object the node
-       * is placed (when reading from the cache), as well as to inform the
-       * reference counting algorithm when to clean this snapshot up.
-       */
-      public readonly inbound: [NodeReference],
-
-      /**
-       * The node snapshots that this one points to.
-       */
-      readonly outbound?: NodeSnapshot.NodeReference[],
-    ) {}
-
   }
 
 }

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -345,14 +345,14 @@ export class SnapshotEditor {
       // We may have deleted the node.
       if (current) return current;
       // If so, we should start fresh.
-      newSnapshot = new NodeSnapshot.Entity({});
+      newSnapshot = new NodeSnapshot({});
     } else {
       const parent = this._parent.getSnapshot(id);
       const value = parent ? { ...parent.node } : {};
       const inbound = parent && parent.inbound ? [...parent.inbound] : undefined;
       const outbound = parent && parent.outbound ? [...parent.outbound] : undefined;
 
-      newSnapshot = new NodeSnapshot.Entity(value, inbound, outbound);
+      newSnapshot = new NodeSnapshot(value, inbound, outbound);
     }
 
     this._newNodes[id] = newSnapshot;

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -285,6 +285,7 @@ export class SnapshotEditor {
       if (!snapshot || !snapshot.inbound) continue;
 
       for (const { id, path } of snapshot.inbound) {
+        if (!path) continue;
         this._setValue(id, path, snapshot.node, false);
         if (this._rebuiltNodeIds.has(id)) continue;
 

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -9,6 +9,7 @@ import {
   isObject,
   isScalar,
   lazyImmutableDeepSet,
+  parameterizedEdgesForOperation,
   removeNodeReference,
   walkPayload,
 } from '../util';
@@ -110,6 +111,7 @@ export class SnapshotEditor {
    */
   private _mergePayloadValues(query: Query, fullPayload: object): ReferenceEdit[] {
     const { entityIdForNode } = this._config;
+    const edgeMap = parameterizedEdgesForOperation(query.document);
 
     const queue = [{ containerId: query.rootId, containerPayload: fullPayload }];
     const referenceEdits = [] as ReferenceEdit[];
@@ -118,7 +120,7 @@ export class SnapshotEditor {
       const { containerId, containerPayload } = queue.pop() as { containerId: NodeId, containerPayload: any };
       const container = this.get(containerId);
 
-      walkPayload(containerPayload, container, (path, payloadValue, nodeValue) => {
+      walkPayload(containerPayload, container, edgeMap, (path, payloadValue, nodeValue, parameterizedEdge) => {
         let nextNodeId = isObject(payloadValue) ? entityIdForNode(payloadValue) : undefined;
         const prevNodeId = isObject(nodeValue) ? entityIdForNode(nodeValue) : undefined;
 

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -345,7 +345,7 @@ export class SnapshotEditor {
       // We may have deleted the node.
       if (current) return current;
       // If so, we should start fresh.
-      newSnapshot = new NodeSnapshot({});
+      newSnapshot = new NodeSnapshot();
     } else {
       const parent = this._parent.getSnapshot(id);
       const value = parent ? { ...parent.node } : {};

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -139,6 +139,11 @@ export class SnapshotEditor {
             addNodeReference('inbound', edgeSnapshot, containerId);
           }
           // We walk the values of the parameterized edge like any other entity.
+          //
+          // EXCEPT: We re-visit the payload, in case it might _directly_
+          // reference an entity.  This allows us to build a chain of references
+          // where the parameterized value points _directly_ to a particular
+          // entity node.
           queue.push({ containerId: edgeId, containerPayload: payloadValue, visitRoot: true });
 
           // Stop the walk for this subgraph.

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -25,6 +25,15 @@ export interface EditedSnapshot {
 }
 
 /**
+ * Used when walking payloads to merge.
+ */
+interface MergeQueueItem {
+  containerId: NodeId;
+  containerPayload: any;
+  visitRoot: boolean;
+}
+
+/**
  * Describes an edit to a reference contained within a node.
  */
 interface ReferenceEdit {
@@ -115,11 +124,11 @@ export class SnapshotEditor {
     const { entityIdForNode } = this._config;
     const edgeMap = parameterizedEdgesForOperation(query.document);
 
-    const queue = [{ containerId: query.rootId, containerPayload: fullPayload, visitRoot: false }];
+    const queue = [{ containerId: query.rootId, containerPayload: fullPayload, visitRoot: false }] as MergeQueueItem[];
     const referenceEdits = [] as ReferenceEdit[];
 
     while (queue.length) {
-      const { containerId, containerPayload, visitRoot } = queue.pop() as { containerId: NodeId, containerPayload: any, visitRoot: boolean };
+      const { containerId, containerPayload, visitRoot } = queue.pop() as MergeQueueItem;
       const container = this.get(containerId);
 
       walkPayload(containerPayload, container, edgeMap, visitRoot, (path, payloadValue, nodeValue, parameterizedEdge) => {

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -180,3 +180,25 @@ function _valueFromNode(node: ValueNode): any {
     return node.value;
   }
 }
+
+/**
+ * Sub values in for any variables required by an edge's args.
+ */
+export function expandEdgeArguments(edge: ParameterizedEdge, variables: object = {}): object {
+  const edgeArguments = {} as any;
+  // TODO: Recurse into objects/arrays.
+  for (const key in edge.args) {
+    let arg = edge.args[key];
+    if (arg instanceof VariableArgument) {
+      if (!(arg.name in variables)) {
+        // TODO: Detect optional variables?
+        throw new Error(`Expected variable $${arg.name} to exist for query`);
+      }
+      arg = variables[arg.name];
+    }
+
+    edgeArguments[key] = arg;
+  }
+
+  return edgeArguments;
+}

--- a/src/util/collection.ts
+++ b/src/util/collection.ts
@@ -1,4 +1,4 @@
-import { JsonScalar, PathPart } from '../primitive';
+import { PathPart } from '../primitive';
 
 /**
  * Adds values to a set, mutating it.
@@ -18,8 +18,10 @@ export function lazyImmutableDeepSet<TEntity>(
   target: TEntity | undefined,
   original: TEntity | undefined,
   path: PathPart[],
-  value: JsonScalar,
+  value: any,
 ): TEntity {
+  if (!path.length) return value;
+
   let parentNode;
   let targetNode: any = target;
   let originalNode: any = original;

--- a/src/util/references.ts
+++ b/src/util/references.ts
@@ -11,7 +11,7 @@ export type ReferenceType = 'inbound' | 'outbound';
  *
  * Returns whether all references were removed.
  */
-export function removeNodeReference(type: ReferenceType, snapshot: NodeSnapshot, id: NodeId, path: PathPart[]): boolean {
+export function removeNodeReference(type: ReferenceType, snapshot: NodeSnapshot, id: NodeId, path?: PathPart[]): boolean {
   const references = snapshot[type];
   if (!references) {
     throw new Error(`Inconsistent GraphSnapshot: Expected snapshot to have ${type} references`);
@@ -32,7 +32,7 @@ export function removeNodeReference(type: ReferenceType, snapshot: NodeSnapshot,
 /**
  * Mutates a snapshot, adding a new reference to it.
  */
-export function addNodeReference(type: ReferenceType, snapshot: NodeSnapshot, id: NodeId, path: PathPart[]) {
+export function addNodeReference(type: ReferenceType, snapshot: NodeSnapshot, id: NodeId, path?: PathPart[]): void {
   let references = snapshot[type];
   if (!references) {
     references = (snapshot as any)[type] = [];

--- a/src/util/references.ts
+++ b/src/util/references.ts
@@ -40,3 +40,16 @@ export function addNodeReference(type: ReferenceType, snapshot: NodeSnapshot, id
 
   references.push({ id, path });
 }
+
+/**
+ * Whether a snapshot has a specific reference.
+ */
+export function hasNodeReference(snapshot: NodeSnapshot, type: ReferenceType, id: NodeId, path?: PathPart[]): boolean {
+  const references = snapshot[type];
+  if (!references) return false;
+  for (const reference of references) {
+    if (reference.id === id && lodashIsEqual(reference.path, path)) return true;
+  }
+
+  return false;
+}

--- a/src/util/tree.ts
+++ b/src/util/tree.ts
@@ -45,7 +45,7 @@ export type Visitor = (
  * (`EntityType`) is reached.  References skip over arrays, so that they apply
  * to the values inside the (homogeneous) array.
  */
-export function walkPayload(payload: any, node: any, edgeMap: ParameterizedEdgeMap | undefined, visitor: Visitor) {
+export function walkPayload(payload: any, node: any, edgeMap: ParameterizedEdgeMap | undefined, visitRoot: boolean, visitor: Visitor) {
   // We perform a pretty standard depth-first traversal, with the addition of
   // tracking the current path at each node.
   const stack = [new WalkNode(payload, node, edgeMap, 0)];
@@ -55,9 +55,12 @@ export function walkPayload(payload: any, node: any, edgeMap: ParameterizedEdgeM
     const walkNode = stack.pop() as WalkNode;
 
     // Don't visit the root.
-    if (walkNode.key !== undefined) {
+    if (walkNode.key !== undefined || visitRoot) {
       path.splice(walkNode.depth - 1);
-      path.push(walkNode.key);
+      if (walkNode.key !== undefined) {
+        path.push(walkNode.key);
+      }
+
       const parameterizedEdge = walkNode.edgeMap instanceof ParameterizedEdge ? walkNode.edgeMap : undefined;
       const skipChildren = visitor(path, walkNode.payload, walkNode.node, parameterizedEdge);
       if (skipChildren) continue;

--- a/src/util/tree.ts
+++ b/src/util/tree.ts
@@ -1,5 +1,7 @@
 import { PathPart } from '../primitive';
 
+import { ParameterizedEdge, ParameterizedEdgeMap } from './ast';
+
 /**
  * Represents a node (of all values at the same location in their trees), used
  * by the depth-first walk.
@@ -10,6 +12,8 @@ class WalkNode {
     public readonly payload: any,
     /** The value of the current node at this location in the walk. */
     public readonly node: any,
+    /** The value of the edge map at this location in the walk. */
+    public readonly edgeMap: ParameterizedEdgeMap | ParameterizedEdge | undefined,
     /** The depth of the node (allows us to set the path correctly). */
     public readonly depth: number,
     /** The key/index of this node, relative to its parent. */
@@ -25,7 +29,7 @@ export type Visitor = (
   path: PathPart[],
   payloadValue: any,
   nodeValue: any,
-  // TODO: Walk for parameterized edges.
+  parameterizedEdge?: ParameterizedEdge,
 ) => void | boolean;
 
 /**
@@ -37,14 +41,14 @@ export type Visitor = (
  * node, effectively treating it as a leaf.
  *
  * All values from the node are walked following the same path.  Similarly,
- * all values from `references` are walked, but they are only provided if a leaf
+ * all values from `edgeMap` are walked, but they are only provided if a leaf
  * (`EntityType`) is reached.  References skip over arrays, so that they apply
  * to the values inside the (homogeneous) array.
  */
-export function walkPayload(payload: any, node: any, visitor: Visitor) {
+export function walkPayload(payload: any, node: any, edgeMap: ParameterizedEdgeMap | undefined, visitor: Visitor) {
   // We perform a pretty standard depth-first traversal, with the addition of
   // tracking the current path at each node.
-  const stack = [new WalkNode(payload, node, 0)];
+  const stack = [new WalkNode(payload, node, edgeMap, 0)];
   const path = [] as PathPart[];
 
   while (stack.length) {
@@ -54,7 +58,8 @@ export function walkPayload(payload: any, node: any, visitor: Visitor) {
     if (walkNode.key !== undefined) {
       path.splice(walkNode.depth - 1);
       path.push(walkNode.key);
-      const skipChildren = visitor(path, walkNode.payload, walkNode.node);
+      const parameterizedEdge = walkNode.edgeMap instanceof ParameterizedEdge ? walkNode.edgeMap : undefined;
+      const skipChildren = visitor(path, walkNode.payload, walkNode.node, parameterizedEdge);
       if (skipChildren) continue;
     }
 
@@ -63,16 +68,16 @@ export function walkPayload(payload: any, node: any, visitor: Visitor) {
     const newDepth = walkNode.depth + 1;
     if (Array.isArray(walkNode.payload)) {
       for (let index = walkNode.payload.length - 1; index >= 0; index--) {
-        // Note that we DO NOT walk into `references` for array values; the
-        // references is blind to them, and continues to apply to all values
-        // contained within the array.
-        stack.push(new WalkNode(get(walkNode.payload, index), get(walkNode.node, index), newDepth, index));
+        // Note that we DO NOT walk into `edgeMap` for array values; the edge
+        // map is blind to them, and continues to apply to all values contained
+        // within the array.
+        stack.push(new WalkNode(get(walkNode.payload, index), get(walkNode.node, index), walkNode.edgeMap, newDepth, index));
       }
     } else if (walkNode.payload !== null && typeof walkNode.payload === 'object') {
       const keys = Object.getOwnPropertyNames(walkNode.payload);
       for (let index = keys.length - 1; index >= 0; index--) {
         const key = keys[index];
-        stack.push(new WalkNode(get(walkNode.payload, key), get(walkNode.node, key), newDepth, key));
+        stack.push(new WalkNode(get(walkNode.payload, key), get(walkNode.node, key), get(walkNode.edgeMap, key), newDepth, key));
       }
     }
 


### PR DESCRIPTION
These are a bit tricky to understand at first glance:

* Whenever we encounter a parameterized edge in a response payload, we create a new NodeSnapshot to hold the value of that edge (for its particular set of arguments)
* That NodeSnapshot will have an incoming reference from its container, _with no path_ (the path is encoded in its id, and we do not want it to modify the containing node).
* We allow these snapshots to _directly_ reference other nodes (e.g. have outgoing references with an `[]` path)