### PR TITLE
Read support

### DIFF
--- a/scripts/test:unit.sh
+++ b/scripts/test:unit.sh
@@ -41,8 +41,8 @@ export JEST_SUITE_NAME="test:unit"
 export JEST_JUNIT_OUTPUT=./output/test:unit/report.xml
 
 # On remote test passes, we build once up front; and run/release based on that.
-if [[ "${CI}" == "" ]]; then
-  run compile
-fi
+# if [[ "${CI}" == "" ]]; then
+#   run compile
+# fi
 
 node "${NODE_OPTIONS[@]}" ./node_modules/.bin/jest "${OPTIONS[@]}" "${FILES[@]}"

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -147,7 +147,13 @@ export class SnapshotEditor {
           const containerSnapshot = this._ensureNewSnapshot(containerId);
           if (!hasNodeReference(containerSnapshot, 'outbound', edgeId)) {
             addNodeReference('outbound', containerSnapshot, edgeId);
-            const edgeSnapshot = this._ensureNewSnapshot(edgeId);
+            // This is a bit arcane, but if we
+            let initialValue;
+            if (Array.isArray(payloadValue)) {
+              initialValue = [];
+              initialValue.length = payloadValue.length;
+            }
+            const edgeSnapshot = this._ensureNewSnapshot(edgeId, initialValue);
             addNodeReference('inbound', edgeSnapshot, containerId);
           }
           // We walk the values of the parameterized edge like any other entity.
@@ -361,7 +367,7 @@ export class SnapshotEditor {
       newSnapshot = new NodeSnapshot();
     } else {
       const parent = this._parent.getSnapshot(id);
-      const value = parent ? { ...parent.node } : undefined;
+      const value = parent ? { ...parent.node } : initialValue;
       const inbound = parent && parent.inbound ? [...parent.inbound] : undefined;
       const outbound = parent && parent.outbound ? [...parent.outbound] : undefined;
 

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -361,7 +361,7 @@ export class SnapshotEditor {
       newSnapshot = new NodeSnapshot();
     } else {
       const parent = this._parent.getSnapshot(id);
-      const value = parent ? { ...parent.node } : {};
+      const value = parent ? { ...parent.node } : undefined;
       const inbound = parent && parent.inbound ? [...parent.inbound] : undefined;
       const outbound = parent && parent.outbound ? [...parent.outbound] : undefined;
 

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -348,7 +348,8 @@ export class SnapshotEditor {
   }
 
   /**
-   * TODO: Support more than just entity snapshots.
+   * Ensures that we have built a new version of a snapshot for node `id` (and
+   * that it is referenced by `_newNodes`).
    */
   private _ensureNewSnapshot(id: NodeId, initialValue?: object): NodeSnapshot {
     let newSnapshot;

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -45,7 +45,7 @@ export function read(config: Configuration, query: Query, snapshot: GraphSnapsho
 class OverlayWalkNode {
   constructor(
     /**  */
-    public readonly value: object,
+    public readonly value: any,
     /**  */
     public readonly containerId: NodeId,
     /**  */
@@ -68,7 +68,7 @@ export function _overlayParameterizedValues(
   config: Configuration,
   snapshot: GraphSnapshot,
   edges: ParameterizedEdgeMap,
-  result: object,
+  result: any,
 ): object {
   const newResult = result ? Object.create(result) : {};
   // TODO: This logic sucks.  We'd do much better if we had knowledge of the
@@ -96,12 +96,22 @@ export function _overlayParameterizedValues(
       if (edge && !child) {
         child = {};
       }
-
       value[key] = child;
 
       if (!edge) continue;
       const newPath = childId ? [] : [...path, key];
-      queue.push(new OverlayWalkNode(child, childId || containerId, edge, newPath))
+      const newContainerId = childId || containerId;
+
+      if (Array.isArray(child)) {
+        for (let i = child.length - 1; i >= 0; i--) {
+          if (child[i] === undefined) {
+            child[i] = {};
+          }
+          queue.push(new OverlayWalkNode(child[i], newContainerId, edge, [...newPath, i]));
+        }
+      } else {
+        queue.push(new OverlayWalkNode(child, newContainerId, edge, newPath))
+      }
     }
   }
 

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -81,14 +81,15 @@ export function _overlayParameterizedValues(
 
     for (const key in edgeMap) {
       let edge = edgeMap[key] as any;
-      let child;
+      let child, childId;
       if (edge instanceof ParameterizedEdge) {
         const args = expandEdgeArguments(edge, query.variables);
-        const valueId = nodeIdForParameterizedValue(containerId, [...path, key], args);
-        child = snapshot.get(valueId);
+        childId = nodeIdForParameterizedValue(containerId, [...path, key], args);
+        child = snapshot.get(childId);
         edge = edge.children;
       } else {
-        child = value[key]
+        child = value[key];
+        childId = config.entityIdForNode(child);
       }
 
       // Make sure that we fill in the path if there are further edges.
@@ -99,7 +100,6 @@ export function _overlayParameterizedValues(
       value[key] = child;
 
       if (!edge) continue;
-      const childId = config.entityIdForNode(child);
       const newPath = childId ? [] : [...path, key];
       queue.push(new OverlayWalkNode(child, childId || containerId, edge, newPath))
     }

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -92,26 +92,26 @@ export function _overlayParameterizedValues(
         childId = config.entityIdForNode(child);
       }
 
-      // Make sure that we fill in the path if there are further edges.
-      if (edge && !child) {
-        child = {};
-      }
-      value[key] = child;
+      if (edge) {
+        const newPath = childId ? [] : [...path, key];
+        const newContainerId = childId || containerId;
 
-      if (!edge) continue;
-      const newPath = childId ? [] : [...path, key];
-      const newContainerId = childId || containerId;
-
-      if (Array.isArray(child)) {
-        for (let i = child.length - 1; i >= 0; i--) {
-          if (child[i] === undefined) {
-            child[i] = {};
+        if (Array.isArray(child)) {
+          child = [...child];
+          for (let i = child.length - 1; i >= 0; i--) {
+            if (child[i] === undefined) {
+              child[i] = {};
+            }
+            queue.push(new OverlayWalkNode(child[i], newContainerId, edge, [...newPath, i]));
           }
-          queue.push(new OverlayWalkNode(child[i], newContainerId, edge, [...newPath, i]));
+
+        } else {
+          child = child ? Object.create(child) : {};
+          queue.push(new OverlayWalkNode(child, newContainerId, edge, newPath))
         }
-      } else {
-        queue.push(new OverlayWalkNode(child, newContainerId, edge, newPath))
       }
+
+      value[key] = child;
     }
   }
 

--- a/src/util/tree.ts
+++ b/src/util/tree.ts
@@ -1,3 +1,9 @@
+/**
+ * @fileoverview
+ *
+ * Several specialized tree walkers for cache operations.
+ */
+
 import { // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
   DocumentNode,
   FieldNode,

--- a/test/unit/operations/read.ts
+++ b/test/unit/operations/read.ts
@@ -1,0 +1,152 @@
+import { Configuration } from '../../../src/Configuration';
+import { GraphSnapshot } from '../../../src/GraphSnapshot';
+import { read, write } from '../../../src/operations';
+import { StaticNodeId } from '../../../src/schema';
+import { query } from '../../helpers';
+
+const { QueryRoot: QueryRootId } = StaticNodeId;
+
+describe(`operations.read`, () => {
+
+  const config: Configuration = {
+    entityIdForNode: (node: any) => {
+      return (node && node.id) ? String(node.id) : undefined;
+    },
+  };
+
+  const viewerQuery = query(`{
+    viewer {
+      id
+      name
+    }
+  }`);
+
+  describe(`with an empty cache`, () => {
+
+    let snapshot: GraphSnapshot;
+    beforeAll(() => {
+      snapshot = new GraphSnapshot();
+    });
+
+    it(`returns undefined when fetching anything.`, () => {
+      expect(read(config, viewerQuery, snapshot).result).to.eq(undefined);
+    });
+
+    it(`is marked incomplete`, () => {
+      expect(read(config, viewerQuery, snapshot).complete).to.eq(false);
+    });
+
+    it(`includes no node ids if requested`, () => {
+      expect(Array.from(read(config, viewerQuery, snapshot, true).nodeIds)).to.have.members([]);
+    });
+
+  });
+
+  describe(`with a complete cache`, () => {
+
+    let snapshot: GraphSnapshot;
+    beforeAll(() => {
+      snapshot = write(config, new GraphSnapshot(), viewerQuery, {
+        viewer: {
+          id: 123,
+          name: 'Foo Bar',
+        },
+      }).snapshot;
+    });
+
+    it(`returns the selected values.`, () => {
+      const { result } = read(config, viewerQuery, snapshot);
+      expect(result).to.deep.eq({
+        viewer: {
+          id: 123,
+          name: 'Foo Bar',
+        },
+      });
+    });
+
+    it(`is marked complete`, () => {
+      const { complete } = read(config, viewerQuery, snapshot);
+      expect(complete).to.eq(true);
+    });
+
+    it(`includes all related node ids, if requested`, () => {
+      const { nodeIds } = read(config, viewerQuery, snapshot, true);
+      expect(Array.from(nodeIds)).to.have.members([QueryRootId, '123']);
+    });
+
+  });
+
+  describe(`with a partial cache`, () => {
+
+    let snapshot: GraphSnapshot;
+    beforeAll(() => {
+      snapshot = write(config, new GraphSnapshot(), viewerQuery, {
+        viewer: {
+          id: 123,
+        },
+      }).snapshot;
+    });
+
+    it(`returns the selected values.`, () => {
+      const { result } = read(config, viewerQuery, snapshot);
+      expect(result).to.deep.eq({
+        viewer: {
+          id: 123,
+        },
+      });
+    });
+
+    it(`is marked incomplete`, () => {
+      const { complete } = read(config, viewerQuery, snapshot);
+      expect(complete).to.eq(false);
+    });
+
+    it(`includes all related node ids, if requested`, () => {
+      const { nodeIds } = read(config, viewerQuery, snapshot, true);
+      expect(Array.from(nodeIds)).to.have.members([QueryRootId, '123']);
+    });
+
+  });
+
+
+  describe(`with arrays of complete values`, () => {
+
+    let snapshot: GraphSnapshot;
+    beforeAll(() => {
+      snapshot = write(config, new GraphSnapshot(), viewerQuery, {
+        viewer: [
+          { id: 1, name: 'Foo' },
+          { id: 2, name: 'Bar' },
+          { id: 3, name: 'Baz' },
+        ],
+      }).snapshot;
+    });
+
+    it(`returns the selected values.`, () => {
+      const { result } = read(config, viewerQuery, snapshot);
+      expect(result).to.deep.eq({
+        viewer: [
+          { id: 1, name: 'Foo' },
+          { id: 2, name: 'Bar' },
+          { id: 3, name: 'Baz' },
+        ],
+      });
+    });
+
+    it(`is marked complete`, () => {
+      const { complete } = read(config, viewerQuery, snapshot);
+      expect(complete).to.eq(true);
+    });
+
+    it(`includes all related node ids, if requested`, () => {
+      const { nodeIds } = read(config, viewerQuery, snapshot, true);
+      expect(Array.from(nodeIds)).to.have.members([QueryRootId, '1', '2', '3']);
+    });
+
+  });
+
+  describe(`parameterized edges`, () => {
+
+  });
+
+});

--- a/test/unit/operations/write.ts
+++ b/test/unit/operations/write.ts
@@ -904,6 +904,13 @@ describe(`operations.write`, () => {
         ]);
       });
 
+      it(`writes an array with the correct length`, () => {
+        // This is a bit arcane, but it ensures that _overlayParameterizedValues
+        // behaves properly when iterating arrays that contain _only_
+        // parameterized edges.
+        expect(snapshot.get(containerId)).to.deep.eq([undefined, undefined]);
+      });
+
     });
 
   });


### PR DESCRIPTION
This fills in the guts to satisfy our reads:

* Fetches straight values from the cache.
* Checks whether the cache satisfies the selection set of the requester.
* Overlays parameterized values on top of the results (via `Object.create`)
* Collects the set of node ids selected by the query

---

I'm not particularly happy with how `_overlayParameterizedValues` shook out.  There's been a lot of semi-repetitive tree walking, and there's likely opportunity for abstraction; but not clear how to do it without really ratcheting up complexity