### PR TITLE
Fix support for arrays of items directly inside parameterized edges

### DIFF
--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -109,23 +109,26 @@ export function _overlayParameterizedValues(
         childId = config.entityIdForNode(child);
       }
 
+      // Should we continue the walk?
       if (edge) {
-        const newPath = childId ? [] : [...path, key];
-        const newContainerId = childId || containerId;
-
         if (Array.isArray(child)) {
           child = [...child];
           for (let i = child.length - 1; i >= 0; i--) {
             if (child[i] === undefined) {
               child[i] = {};
             }
-            queue.push(new OverlayWalkNode(child[i], newContainerId, edge, [...newPath, i]));
+
+            // Give our array children a chance to start a new path.
+            childId = config.entityIdForNode(child[i]) || childId;
+            const newPath = childId ? [] : [...path, key, i];
+            queue.push(new OverlayWalkNode(child[i], childId || containerId, edge, newPath));
           }
 
         } else {
           // TODO: Switch back to Object.create() once we fix shit
           child = child ? { ...child } : {};
-          queue.push(new OverlayWalkNode(child, newContainerId, edge, newPath))
+          const newPath = childId ? [] : [...path, key];
+          queue.push(new OverlayWalkNode(child, childId || containerId, edge, newPath))
         }
       }
 

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -119,9 +119,9 @@ export function _overlayParameterizedValues(
             }
 
             // Give our array children a chance to start a new path.
-            childId = config.entityIdForNode(child[i]) || childId;
-            const newPath = childId ? [] : [...path, key, i];
-            queue.push(new OverlayWalkNode(child[i], childId || containerId, edge, newPath));
+            const arrayChildId = config.entityIdForNode(child[i]) || childId;
+            const newPath = arrayChildId ? [] : [...path, key, i];
+            queue.push(new OverlayWalkNode(child[i], arrayChildId || containerId, edge, newPath));
           }
 
         } else {

--- a/test/unit/operations/read.ts
+++ b/test/unit/operations/read.ts
@@ -247,6 +247,44 @@ describe(`operations.read`, () => {
 
       });
 
+      describe(`and an empty value`, () => {
+
+        let snapshot: GraphSnapshot;
+        beforeAll(() => {
+          snapshot = write(config, empty, nestedQuery, {
+            one: {
+              two: [
+                {
+                  id: 1,
+                  three: {
+                    four: [],
+                  },
+                },
+              ],
+            },
+          }).snapshot;
+        });
+
+        it(`returns the selected values, overlaid on the underlying data`, () => {
+          const { result } = read(config, nestedQuery, snapshot);
+          expect(result).to.deep.equal({
+            one: {
+              two: [
+                {
+                  id: 1,
+                  three: {
+                    four: [],
+                  },
+                },
+              ],
+            },
+          });
+        });
+
+      });
+
+    });
+
     describe(`with a value of []`, () => {
 
       let snapshot: GraphSnapshot;

--- a/test/unit/operations/read.ts
+++ b/test/unit/operations/read.ts
@@ -175,6 +175,7 @@ describe(`operations.read`, () => {
       const nestedQuery = query(`query nested($id: ID!) {
         one {
           two(id: $id) {
+            id
             three {
               four(extra: true) {
                 five
@@ -192,11 +193,13 @@ describe(`operations.read`, () => {
             one: {
               two: [
                 {
+                  id: 1,
                   three: {
                     four: { five: 1 },
                   },
                 },
                 {
+                  id: 2,
                   three: {
                     four: { five: 2 },
                   },
@@ -212,11 +215,13 @@ describe(`operations.read`, () => {
             one: {
               two: [
                 {
+                  id: 1,
                   three: {
                     four: { five: 1 },
                   },
                 },
                 {
+                  id: 2,
                   three: {
                     four: { five: 2 },
                   },
@@ -240,6 +245,24 @@ describe(`operations.read`, () => {
           expect(complete).to.eq(false);
         });
 
+      });
+
+    describe(`with a value of []`, () => {
+
+      let snapshot: GraphSnapshot;
+      beforeAll(() => {
+        snapshot = write(config, empty, parameterizedQuery, {
+          user: [],
+          stuff: 123,
+        }).snapshot;
+      });
+
+      it(`returns the selected values, overlaid on the underlying data`, () => {
+        const { result } = read(config, parameterizedQuery, snapshot);
+        expect(result).to.deep.equal({
+          user: [],
+          stuff: 123,
+        });
       });
 
     });


### PR DESCRIPTION
If they had an id, we were not resetting the path to take that into account