### PR TITLE
Fix several issues with edge walking

### DIFF
--- a/src/NodeSnapshot.ts
+++ b/src/NodeSnapshot.ts
@@ -9,9 +9,9 @@ export class NodeSnapshot {
     /** A reference to the node this snapshot is about. */
     readonly node?: any,
     /** Other node snapshots that point to this one. */
-    readonly inbound?: NodeSnapshot.NodeReference[],
+    readonly inbound?: NodeSnapshot.Reference[],
     /** The node snapshots that this one points to. */
-    readonly outbound?: NodeSnapshot.NodeReference[],
+    readonly outbound?: NodeSnapshot.Reference[],
   ) {}
 }
 
@@ -22,7 +22,7 @@ export namespace NodeSnapshot {
    *
    * Used when updating the graph, as well as for garbage collection.
    */
-  export interface NodeReference {
+  export interface Reference {
     /**
      * Id of the node that is either doing the referencing (inbound), or being
      * referenced (outbound).

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -73,7 +73,7 @@ export function _overlayParameterizedValues(
   if (!rootSnapshot || !rootSnapshot.outbound) {
     // For now, what's probably good enough is to just stop the walk if we have
     // no root snapshot making outbound references to any other edges.
-    return undefined;
+    return result;
   }
 
   // TODO: A better approach here might be to walk the outbound references from

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -110,7 +110,7 @@ export function _overlayParameterizedValues(
       }
 
       // Should we continue the walk?
-      if (edge) {
+      if (edge && child !== null) {
         if (Array.isArray(child)) {
           child = [...child];
           for (let i = child.length - 1; i >= 0; i--) {

--- a/src/util/references.ts
+++ b/src/util/references.ts
@@ -4,17 +4,22 @@ import { NodeSnapshot } from '../NodeSnapshot';
 import { PathPart } from '../primitive';
 import { NodeId } from '../schema';
 
-export type ReferenceType = 'inbound' | 'outbound';
+export type ReferenceDirection = 'inbound' | 'outbound';
 
 /**
  * Mutates a snapshot, removing an inbound reference from it.
  *
  * Returns whether all references were removed.
  */
-export function removeNodeReference(type: ReferenceType, snapshot: NodeSnapshot, id: NodeId, path?: PathPart[]): boolean {
-  const references = snapshot[type];
+export function removeNodeReference(
+  direction: ReferenceDirection,
+  snapshot: NodeSnapshot,
+  id: NodeId,
+  path?: PathPart[],
+): boolean {
+  const references = snapshot[direction];
   if (!references) {
-    throw new Error(`Inconsistent GraphSnapshot: Expected snapshot to have ${type} references`);
+    throw new Error(`Inconsistent GraphSnapshot: Expected snapshot to have ${direction} references`);
   }
 
   const fromIndex = references.findIndex((reference) => {
@@ -23,7 +28,7 @@ export function removeNodeReference(type: ReferenceType, snapshot: NodeSnapshot,
   references.splice(fromIndex, 1);
 
   if (!references.length) {
-    (snapshot as any)[type] = undefined;
+    (snapshot as any)[direction] = undefined;
   }
 
   return !references.length;
@@ -32,10 +37,15 @@ export function removeNodeReference(type: ReferenceType, snapshot: NodeSnapshot,
 /**
  * Mutates a snapshot, adding a new reference to it.
  */
-export function addNodeReference(type: ReferenceType, snapshot: NodeSnapshot, id: NodeId, path?: PathPart[]): void {
-  let references = snapshot[type];
+export function addNodeReference(
+  direction: ReferenceDirection,
+  snapshot: NodeSnapshot,
+  id: NodeId,
+  path?: PathPart[],
+): void {
+  let references = snapshot[direction];
   if (!references) {
-    references = (snapshot as any)[type] = [];
+    references = (snapshot as any)[direction] = [];
   }
 
   references.push({ id, path });
@@ -44,7 +54,12 @@ export function addNodeReference(type: ReferenceType, snapshot: NodeSnapshot, id
 /**
  * Whether a snapshot has a specific reference.
  */
-export function hasNodeReference(snapshot: NodeSnapshot, type: ReferenceType, id: NodeId, path?: PathPart[]): boolean {
+export function hasNodeReference(
+  snapshot: NodeSnapshot,
+  type: ReferenceDirection,
+  id: NodeId,
+  path?: PathPart[],
+): boolean {
   const references = snapshot[type];
   if (!references) return false;
   for (const reference of references) {

--- a/test/unit/operations/read.ts
+++ b/test/unit/operations/read.ts
@@ -325,6 +325,27 @@ describe(`operations.read`, () => {
 
       });
 
+      describe(`and a null container`, () => {
+
+        let snapshot: GraphSnapshot;
+        beforeAll(() => {
+          snapshot = write(config, empty, nestedQuery, {
+            one: {
+              two: null,
+            },
+          }).snapshot;
+        });
+
+        it(`returns the selected values, overlaid on the underlying data`, () => {
+          const { result } = read(config, nestedQuery, snapshot);
+          expect(result).to.deep.equal({
+            one: {
+              two: null,
+            },
+          });
+        });
+
+      });
     });
 
     describe(`with a value of []`, () => {

--- a/test/unit/operations/read.ts
+++ b/test/unit/operations/read.ts
@@ -329,6 +329,25 @@ describe(`operations.read`, () => {
 
         let snapshot: GraphSnapshot;
         beforeAll(() => {
+          snapshot = write(config, empty, nestedQuery, { one: null }).snapshot;
+        });
+
+        it(`returns the selected values, overlaid on the underlying data`, () => {
+          const { result } = read(config, nestedQuery, snapshot);
+          expect(result).to.deep.equal({ one: null });
+        });
+
+        it(`is marked complete`, () => {
+          const { complete } = read(config, nestedQuery, snapshot);
+          expect(complete).to.eq(true);
+        });
+
+      });
+
+      describe(`and a null root snapshot`, () => {
+
+        let snapshot: GraphSnapshot;
+        beforeAll(() => {
           snapshot = write(config, empty, nestedQuery, {
             one: {
               two: null,
@@ -345,7 +364,46 @@ describe(`operations.read`, () => {
           });
         });
 
+        it(`is marked complete`, () => {
+          const { complete } = read(config, nestedQuery, snapshot);
+          expect(complete).to.eq(true);
+        });
+
       });
+
+      describe(`and a null intermediate node`, () => {
+
+        let snapshot: GraphSnapshot;
+        beforeAll(() => {
+          snapshot = write(config, empty, nestedQuery, {
+            one: {
+              two: {
+                id: 1,
+                three: null,
+              },
+            },
+          }).snapshot;
+        });
+
+        it(`returns the selected values, overlaid on the underlying data`, () => {
+          const { result } = read(config, nestedQuery, snapshot);
+          expect(result).to.deep.equal({
+            one: {
+              two: {
+                id: 1,
+                three: null,
+              },
+            },
+          });
+        });
+
+        it(`is marked complete`, () => {
+          const { complete } = read(config, nestedQuery, snapshot);
+          expect(complete).to.eq(true);
+        });
+
+      });
+
     });
 
     describe(`with a value of []`, () => {


### PR DESCRIPTION
* We weren't treating `null`s as present for `complete`
* Several bugs related to `null` values partway down a paramterized path