### PR TITLE
Drop the postinstall for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   ],
   "files": [
     "**/*.md",
-    "scripts/",
     "src/",
     "tsconfig.json"
   ],
@@ -26,7 +25,6 @@
     "dev": "./scripts/dev.sh",
     "fix:style": "./scripts/fix:style.sh",
     "greenkeeper:lockfile": "./scripts/greenkeeper:lockfile.sh",
-    "postinstall": "node ./scripts/postinstall.js",
     "release": "./scripts/release.sh",
     "test": "./scripts/test.sh",
     "test:compile": "./scripts/test:compile.sh",


### PR DESCRIPTION
It's breaking regular installs:

```
> apollo-cache-hermes@0.2.0-alpha postinstall <project>/node_modules/apollo-cache-hermes
> node ./scripts/postinstall.js

module.js:471
    throw err;
    ^

Error: Cannot find module '<project>/node_modules/apollo-cache-hermes/scripts/postinstall.js'
```