### PR TITLE
Always create dynamicEdge even when the field itself doesn't contain any dynamic feature

### DIFF
--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -203,7 +203,7 @@ export class SnapshotEditor {
           payloadValue = null;
         }
 
-        if (dynamicEdges instanceof DynamicEdge && dynamicEdges.parameterizedEdgeArgs) {
+        if (dynamicEdges && dynamicEdges.parameterizedEdgeArgs) {
           // swap in any variables.
           const edgeArguments = expandEdgeArguments(dynamicEdges.parameterizedEdgeArgs, query.variables);
 
@@ -257,7 +257,7 @@ export class SnapshotEditor {
           // So, walk if we have new values, otherwise we're done for this
           // subgraph.
           if (nextNodeId) {
-            const updateEdge = dynamicEdges instanceof DynamicEdge ? dynamicEdges.children : dynamicEdges;
+            const updateEdge = dynamicEdges && dynamicEdges.children ? dynamicEdges.children : dynamicEdges;
             queue.push({ containerId: nextNodeId, containerPayload: payloadValue, visitRoot: false, edges: updateEdge });
           }
           // Stop the walk for this subgraph.

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -7,7 +7,6 @@ import { NodeId, ParsedQuery, Query } from '../schema';
 import {
   expandEdgeArguments,
   isObject,
-  DynamicEdge,
   DynamicEdgeMap,
 } from '../util';
 
@@ -117,11 +116,11 @@ export function _walkAndOverlayDynamicValues(
     for (const key in edgeMap) {
       if (key === "entityIdAlias") continue;
       const edge = edgeMap[key];
-      let nextEdge = edge;
+      let nextEdge: DynamicEdgeMap | undefined;
       let child, childId;
       let fieldName = key;
 
-      if (edge instanceof DynamicEdge) {
+      if (edge) {
         // If exist filedName property then the current key is an alias
         fieldName = edge.fieldName ? edge.fieldName : key;
         nextEdge = edge.children;
@@ -142,18 +141,18 @@ export function _walkAndOverlayDynamicValues(
 
       // Should we continue the walk?
       // TODO : comment
-      if (nextEdge && !(nextEdge instanceof DynamicEdge) && child !== null) {
+      if (nextEdge && child !== null) {
         if (Array.isArray(child)) {
           child = [...child];
           for (let i = child.length - 1; i >= 0; i--) {
             if (child[i] === null) continue;
             child[i] = _wrapValue(child[i]);
-            queue.push(new OverlayWalkNode(child[i], containerId, nextEdge as DynamicEdgeMap, [...path, fieldName, i]));
+            queue.push(new OverlayWalkNode(child[i], containerId, nextEdge, [...path, fieldName, i]));
           }
 
         } else {
           child = _wrapValue(child);
-          queue.push(new OverlayWalkNode(child, containerId, nextEdge as DynamicEdgeMap, [...path, fieldName]))
+          queue.push(new OverlayWalkNode(child, containerId, nextEdge, [...path, fieldName]))
         }
       }
 

--- a/src/util/tree.ts
+++ b/src/util/tree.ts
@@ -41,7 +41,7 @@ export type PayloadVisitor = (
   path: PathPart[],
   payloadValue: any,
   nodeValue: any,
-  dynamicEdge: DynamicEdge | DynamicEdgeMap | undefined,
+  dynamicEdge: DynamicEdge | undefined,
 ) => boolean;
 
 /**

--- a/test/unit/util/ast.ts
+++ b/test/unit/util/ast.ts
@@ -97,13 +97,25 @@ describe(`util.ast`, () => {
           }
         }`);
         expect(map).to.deep.eq({
-          foo: {
-            fizz: {
-              buzz: {
-                moo: new DynamicEdge({ val: 1.234 }),
-              },
+          foo: new DynamicEdge(
+            /* parameterizedEdgeArgs */ undefined,
+            /* fieldName */ undefined,
+            {
+              fizz: new DynamicEdge(
+                /* parameterizedEdgeArgs */ undefined,
+                /* fieldName */ undefined,
+                {
+                  buzz: new DynamicEdge(
+                    /* paramterizedEdgeArgs */ undefined,
+                    /* fieldName */ undefined,
+                    {
+                      moo: new DynamicEdge({ val: 1.234 }),
+                    },
+                  ),
+                }
+              ),
             },
-          },
+          ),
         });
       });
 
@@ -121,9 +133,13 @@ describe(`util.ast`, () => {
         `);
 
         expect(map).to.deep.eq({
-          stuff: {
-            things: new DynamicEdge({ count: 5 }),
-          },
+          stuff: new DynamicEdge(
+            /* parameterizedEdgeArgs */ undefined,
+            /* fieldName */ undefined,
+            {
+              things: new DynamicEdge({ count: 5 }),
+            }
+          ),
         });
       });
 
@@ -216,10 +232,14 @@ describe(`util.ast`, () => {
           }
         `);
         expect(map).to.deep.eq({
-          user: {
-            ID: new DynamicEdge(/* parameterizedEdgeArgs */ undefined, /* fiedlName */ 'id'),
-            FirstName: new DynamicEdge(/* parameterizedEdgeArgs */ undefined, /* fiedlName */ 'name'),
-          },
+          user: new DynamicEdge(
+            /* paramterizedEdgeArgs */ undefined,
+            /* fieldName */ undefined,
+            {
+              ID: new DynamicEdge(/* parameterizedEdgeArgs */ undefined, /* fiedlName */ 'id'),
+              FirstName: new DynamicEdge(/* parameterizedEdgeArgs */ undefined, /* fiedlName */ 'name'),
+            }
+          ),
         });
       });
 
@@ -237,8 +257,8 @@ describe(`util.ast`, () => {
             /* parameterizedEdgeArgs */ undefined,
             /* fiedlName */ 'user',
             {
-              ID: new DynamicEdge(/* parameterizedEdgeArgs */ undefined, /* fiedlName */ 'id'),
-              FirstName: new DynamicEdge(/* parameterizedEdgeArgs */ undefined, /* fiedlName */ 'name'),
+              ID: new DynamicEdge(/* parameterizedEdgeArgs */ undefined, /* fiedlName */ 'id', /* children */ undefined),
+              FirstName: new DynamicEdge(/* parameterizedEdgeArgs */ undefined, /* fiedlName */ 'name', /* children */ undefined),
             }
           ),
         });


### PR DESCRIPTION
Currently when the field itself doesn't contain any dynamic feature, we will just map field's name to dynamicEdgeMap of children, this change force the creation of DynamicEdge if children or itself containing some dynamic features