### PR TITLE
Assert JSON-serializable types where we can

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -1,4 +1,4 @@
-import { JsonObject } from './primitive';
+import { JsonObject, JsonValue } from './primitive';
 import { Queryable } from './Queryable';
 import { CacheTransaction } from './CacheTransaction';
 import { CacheSnapshot } from './CacheSnapshot';
@@ -39,7 +39,7 @@ export class Cache implements Queryable {
    * TODO: Can we drop non-optimistic reads?
    * https://github.com/apollographql/apollo-client/issues/1971#issuecomment-319402170
    */
-  read(query: Query, optimistic?: boolean): { result: any, complete: boolean } {
+  read(query: Query, optimistic?: boolean): { result?: JsonValue, complete: boolean } {
     // TODO: Can we drop non-optimistic reads?
     // https://github.com/apollographql/apollo-client/issues/1971#issuecomment-319402170
     const snapshot = optimistic ? this._snapshot.optimistic : this._snapshot.baseline;

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -1,3 +1,4 @@
+import { JsonObject } from './primitive';
 import { Queryable } from './Queryable';
 import { CacheTransaction } from './CacheTransaction';
 import { CacheSnapshot } from './CacheSnapshot';
@@ -59,7 +60,7 @@ export class Cache implements Queryable {
   /**
    * Writes values for a selection to the cache.
    */
-  write(query: Query, payload: any): void {
+  write(query: Query, payload: JsonObject): void {
     this.transaction(t => t.write(query, payload));
   }
 

--- a/src/CacheTransaction.ts
+++ b/src/CacheTransaction.ts
@@ -2,7 +2,7 @@ import { CacheSnapshot } from './CacheSnapshot';
 import { CacheContext } from './context';
 import { GraphSnapshot } from './GraphSnapshot';
 import { read, write } from './operations';
-import { JsonObject } from './primitive';
+import { JsonObject, JsonValue } from './primitive';
 import { Queryable } from './Queryable';
 import { ChangeId, NodeId, Query, QuerySnapshot } from './schema';
 import { addToSet } from './util';
@@ -31,7 +31,7 @@ export class CacheTransaction implements Queryable {
   /**
    * Executes reads against the current values in the transaction.
    */
-  read(query: Query): { result: any, complete: boolean } {
+  read(query: Query): { result?: JsonValue, complete: boolean } {
     return read(this._context, query, this._snapshot.optimistic);
   }
 

--- a/src/CacheTransaction.ts
+++ b/src/CacheTransaction.ts
@@ -2,6 +2,7 @@ import { CacheSnapshot } from './CacheSnapshot';
 import { CacheContext } from './context';
 import { GraphSnapshot } from './GraphSnapshot';
 import { read, write } from './operations';
+import { JsonObject } from './primitive';
 import { Queryable } from './Queryable';
 import { ChangeId, NodeId, Query, QuerySnapshot } from './schema';
 import { addToSet } from './util';
@@ -41,7 +42,7 @@ export class CacheTransaction implements Queryable {
    * any previous optimistic values.  Otherwise, edits will be made to the
    * baseline state (and any optimistic updates will be replayed over it).
    */
-  write(query: Query, payload: any): void {
+  write(query: Query, payload: JsonObject): void {
     if (this._optimisticChangeId) {
       this._writeOptimistic(query, payload);
     } else {
@@ -80,7 +81,7 @@ export class CacheTransaction implements Queryable {
   /**
    * Merge a payload with the baseline snapshot.
    */
-  private _writeBaseline(query: Query, payload: any) {
+  private _writeBaseline(query: Query, payload: JsonObject) {
     const current = this._snapshot;
 
     const { snapshot: baseline, editedNodeIds } = write(this._context, current.baseline, query, payload);
@@ -107,7 +108,7 @@ export class CacheTransaction implements Queryable {
   /**
    * Merge a payload with the optimistic snapshot.
    */
-  private _writeOptimistic(query: Query, payload: any) {
+  private _writeOptimistic(query: Query, payload: JsonObject) {
     this._deltas.push({ query, payload });
 
     const { snapshot: optimistic, editedNodeIds } = write(this._context, this._snapshot.baseline, query, payload);

--- a/src/DynamicField.ts
+++ b/src/DynamicField.ts
@@ -4,7 +4,7 @@ import { // eslint-disable-line import/no-extraneous-dependencies, import/no-unr
   ValueNode,
 } from 'graphql';
 
-import { JsonScalar, NestedObject } from './primitive';
+import { JsonObject, JsonScalar, NestedObject } from './primitive';
 import { FragmentMap, valueFromNode } from './util';
 
 /**
@@ -151,7 +151,7 @@ export function isDynamicFieldWithArgs(field: any): field is DynamicFieldWithArg
 /**
  * Sub values in for any variables required by a field's args.
  */
-export function expandFieldArguments(args: FieldArguments, variables: object = {}): object {
+export function expandFieldArguments(args: FieldArguments, variables: JsonObject = {}): JsonObject {
   const expanded = {};
   // TODO: Recurse into objects/arrays.
   for (const key in args) {

--- a/src/DynamicField.ts
+++ b/src/DynamicField.ts
@@ -4,7 +4,7 @@ import { // eslint-disable-line import/no-extraneous-dependencies, import/no-unr
   ValueNode,
 } from 'graphql';
 
-import { JsonObject, JsonScalar, NestedObject } from './primitive';
+import { JsonObject, JsonScalar, JsonValue, NestedObject } from './primitive';
 import { FragmentMap, valueFromNode } from './util';
 
 /**
@@ -134,7 +134,7 @@ function _buildFieldArgs(variables: Set<string>, argumentsNode: ArgumentNode[]):
 /**
  * Evaluate a ValueNode and yield its value in its natural JS form.
  */
-function _valueFromNode(variables: Set<string>, node: ValueNode): any {
+function _valueFromNode(variables: Set<string>, node: ValueNode): JsonValue {
   return valueFromNode(node, ({ name: { value } }) => {
     variables.add(value);
     return new VariableArgument(value);

--- a/src/OptimisticUpdateQueue.ts
+++ b/src/OptimisticUpdateQueue.ts
@@ -1,6 +1,7 @@
 import { CacheContext } from './context';
 import { GraphSnapshot } from './GraphSnapshot';
 import { SnapshotEditor } from './operations';
+import { JsonObject } from './primitive';
 import { ChangeId, NodeId, QuerySnapshot } from './schema';
 
 /**
@@ -54,7 +55,7 @@ export class OptimisticUpdateQueue {
     const editor = new SnapshotEditor(context, snapshot);
     for (const update of this._updates) {
       for (const delta of update.deltas) {
-        editor.mergePayload(delta.query, delta.payload);
+        editor.mergePayload(delta.query, delta.payload as JsonObject);
       }
     }
 

--- a/src/Queryable.ts
+++ b/src/Queryable.ts
@@ -1,3 +1,4 @@
+import { JsonObject, JsonValue } from './primitive';
 import { Query } from './schema';
 
 /**
@@ -12,11 +13,11 @@ export interface Queryable {
    * TODO: Can we drop non-optimistic reads?
    * https://github.com/apollographql/apollo-client/issues/1971#issuecomment-319402170
    */
-  read(query: Query, optimistic?: boolean): { result: any, complete: boolean };
+  read(query: Query, optimistic?: boolean): { result?: JsonValue, complete: boolean };
 
   /**
    * Writes values for a selection to the cache.
    */
-  write(query: Query, payload: any): void;
+  write(query: Query, payload: JsonObject): void;
 
 }

--- a/src/apollo/ApolloQueryable.ts
+++ b/src/apollo/ApolloQueryable.ts
@@ -1,3 +1,4 @@
+import { JsonObject } from '../primitive';
 import { Queryable } from '../Queryable';
 
 import * as interfaces from './interfaces';
@@ -42,23 +43,23 @@ export abstract class ApolloQueryable {
 
   readFragment<FragmentType>(options: interfaces.Cache.ReadFragmentOptions, optimistic?: true): FragmentType | null {
     // TODO: Support nested fragments.
-    const query = toQuery(options.fragment, options.variables);
+    const query = toQuery(options.fragment, options.variables as JsonObject);
     return this._queryable.read(query, optimistic).result;
   }
 
   writeResult(options: interfaces.Cache.WriteResultOptions): void {
-    const query = toQuery(options.document, options.variables, options.dataId);
+    const query = toQuery(options.document, options.variables as JsonObject, options.dataId);
     this._queryable.write(query, options.result);
   }
 
   writeQuery(options: interfaces.Cache.WriteQueryOptions): void {
-    const query = toQuery(options.query, options.variables);
+    const query = toQuery(options.query, options.variables as JsonObject);
     this._queryable.write(query, options.data);
   }
 
   writeFragment(options: interfaces.Cache.WriteFragmentOptions): void {
     // TODO: Support nested fragments.
-    const query = toQuery(options.fragment, options.variables, options.id);
+    const query = toQuery(options.fragment, options.variables as JsonObject, options.id);
     this._queryable.write(query, options.data);
   }
 }

--- a/src/apollo/ApolloQueryable.ts
+++ b/src/apollo/ApolloQueryable.ts
@@ -44,7 +44,7 @@ export abstract class ApolloQueryable {
   readFragment<FragmentType>(options: interfaces.Cache.ReadFragmentOptions, optimistic?: true): FragmentType | null {
     // TODO: Support nested fragments.
     const query = toQuery(options.fragment, options.variables as JsonObject);
-    return this._queryable.read(query, optimistic).result;
+    return this._queryable.read(query, optimistic).result as any;
   }
 
   writeResult(options: interfaces.Cache.WriteResultOptions): void {

--- a/src/apollo/util.ts
+++ b/src/apollo/util.ts
@@ -1,11 +1,12 @@
 import { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
 
+import { JsonObject } from '../primitive';
 import { NodeId, Query, StaticNodeId } from '../schema';
 
 /**
  * Builds a query.
  */
-export function toQuery(document: DocumentNode, variables?: object, rootId?: NodeId): Query {
+export function toQuery(document: DocumentNode, variables?: JsonObject, rootId?: NodeId): Query {
   return {
     rootId: rootId || StaticNodeId.QueryRoot,
     document,

--- a/src/context/CacheContext.ts
+++ b/src/context/CacheContext.ts
@@ -1,6 +1,7 @@
 import { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
 import lodashIsEqual = require('lodash.isequal');
 
+import { JsonObject } from '../primitive';
 import { EntityId, ParsedQuery, Query } from '../schema';
 import { addTypenameToDocument, isObject } from '../util';
 
@@ -8,9 +9,9 @@ import { QueryInfo } from './QueryInfo';
 
 export namespace CacheContext {
 
-  export type EntityIdForNode = (node: any) => EntityId | undefined;
-  export type EntityIdMapper = (node: object) => string | number | undefined;
-  export type EntityTransformer = (node: object) => void;
+  export type EntityIdForNode = (node: JsonObject) => EntityId | undefined;
+  export type EntityIdMapper = (node: JsonObject) => string | number | undefined;
+  export type EntityTransformer = (node: JsonObject) => void;
   export type LogEmitter = (message: string, ...metadata: any[]) => void;
   export interface Logger {
     warn: LogEmitter;
@@ -140,7 +141,7 @@ export class CacheContext {
 export function _makeEntityIdMapper(
   mapper: CacheContext.EntityIdMapper = defaultEntityIdMapper,
 ): CacheContext.EntityIdForNode {
-  return function entityIdForNode(node: any) {
+  return function entityIdForNode(node: JsonObject) {
     if (!isObject(node)) return undefined;
 
     // We don't trust upstream implementations.
@@ -151,7 +152,7 @@ export function _makeEntityIdMapper(
   };
 }
 
-export function defaultEntityIdMapper(node: any) {
+export function defaultEntityIdMapper(node: { id?: any }) {
   return node.id;
 }
 

--- a/src/nodes/EntitySnapshot.ts
+++ b/src/nodes/EntitySnapshot.ts
@@ -1,4 +1,4 @@
-import { JsonValue, NestedArray, NestedObject } from '../primitive';
+import { JsonObject, NestedArray, NestedObject } from '../primitive';
 
 import { NodeReference, NodeSnapshot } from './NodeSnapshot';
 
@@ -15,7 +15,7 @@ export { NestedArray, NestedObject };
 export class EntitySnapshot implements NodeSnapshot {
   constructor(
     /** A reference to the entity this snapshot is about. */
-    public node?: JsonValue,
+    public node?: JsonObject,
     /** Other node snapshots that point to this one. */
     public inbound?: NodeReference[],
     /** The node snapshots that this one points to. */

--- a/src/nodes/EntitySnapshot.ts
+++ b/src/nodes/EntitySnapshot.ts
@@ -1,16 +1,21 @@
+import { JsonValue, NestedArray, NestedObject } from '../primitive';
+
 import { NodeReference, NodeSnapshot } from './NodeSnapshot';
+
+// Until https://github.com/Microsoft/TypeScript/issues/9944
+export { NestedArray, NestedObject };
 
 /**
  * Maintains a reference to a single entity within the cached graph, and any
  * bookkeeping metadata associated with it.
- * 
+ *
  * Note that this houses all the _static_ values for an entity, but none of the
  * parameterized values that may also have been queried for it.
  */
 export class EntitySnapshot implements NodeSnapshot {
   constructor(
     /** A reference to the entity this snapshot is about. */
-    public node?: any,
+    public node?: JsonValue,
     /** Other node snapshots that point to this one. */
     public inbound?: NodeReference[],
     /** The node snapshots that this one points to. */

--- a/src/nodes/NodeSnapshot.ts
+++ b/src/nodes/NodeSnapshot.ts
@@ -1,4 +1,4 @@
-import { PathPart } from '../primitive';
+import { JsonValue, PathPart } from '../primitive';
 import { NodeId } from '../schema';
 
 /**
@@ -6,7 +6,7 @@ import { NodeId } from '../schema';
  */
 export interface NodeSnapshot {
   /** A reference to the node this snapshot is about. TODO: Remove? */
-  node?: any;
+  node?: JsonValue;
   /** Other node snapshots that point to this one. */
   inbound?: NodeReference[];
   /** The node snapshots that this one points to. */

--- a/src/nodes/ParameterizedValueSnapshot.ts
+++ b/src/nodes/ParameterizedValueSnapshot.ts
@@ -1,4 +1,9 @@
+import { JsonValue, NestedArray, NestedObject } from '../primitive';
+
 import { NodeSnapshot, NodeReference } from './NodeSnapshot';
+
+// Until https://github.com/Microsoft/TypeScript/issues/9944
+export { NestedArray, NestedObject };
 
 /**
  * Maintains a reference to the value of a specific parameterized field
@@ -11,7 +16,7 @@ import { NodeSnapshot, NodeReference } from './NodeSnapshot';
 export class ParameterizedValueSnapshot implements NodeSnapshot {
   constructor(
     /** A reference to the entity this snapshot is about. */
-    public node?: any,
+    public node?: JsonValue,
     /** Other node snapshots that point to this one. */
     public inbound?: NodeReference[],
     /** The node snapshots that this one points to. */

--- a/src/nodes/clone.ts
+++ b/src/nodes/clone.ts
@@ -1,3 +1,4 @@
+import { JsonObject } from '../primitive';
 import { isObject } from '../util';
 
 import { EntitySnapshot } from './EntitySnapshot';
@@ -21,7 +22,7 @@ export function cloneNodeSnapshot(parent: NodeSnapshot) {
   const outbound = parent.outbound ? [...parent.outbound] : undefined;
 
   if (parent instanceof EntitySnapshot) {
-    return new EntitySnapshot(node, inbound, outbound);
+    return new EntitySnapshot(node as JsonObject, inbound, outbound);
   } else if (parent instanceof ParameterizedValueSnapshot) {
     return new ParameterizedValueSnapshot(node, inbound, outbound);
   } else {

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -8,7 +8,7 @@ import {
 } from '../DynamicField';
 import { GraphSnapshot } from '../GraphSnapshot';
 import { EntitySnapshot, NodeSnapshot, ParameterizedValueSnapshot, cloneNodeSnapshot } from '../nodes';
-import { PathPart } from '../primitive';
+import { JsonObject, PathPart } from '../primitive';
 import { NodeId, ParsedQuery, Query } from '../schema';
 import {
   addNodeReference,
@@ -91,7 +91,7 @@ export class SnapshotEditor {
    * Merge a GraphQL payload (query/fragment/etc) into the snapshot, rooted at
    * the node identified by `rootId`.
    */
-  mergePayload(query: Query, payload: object): void {
+  mergePayload(query: Query, payload: JsonObject): void {
     const parsed = this._context.parseQuery(query);
 
     // First, we walk the payload and apply all _scalar_ edits, while collecting
@@ -128,7 +128,7 @@ export class SnapshotEditor {
    * returned to be applied in a second pass (`_mergeReferenceEdits`), once we
    * can guarantee that all edited nodes have been built.
    */
-  private _mergePayloadValues(query: ParsedQuery, fullPayload: object): ReferenceEdit[] {
+  private _mergePayloadValues(query: ParsedQuery, fullPayload: JsonObject): ReferenceEdit[] {
     const { entityIdForNode } = this._context;
     const { dynamicFieldMap } = query.info;
 

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -446,7 +446,7 @@ export class SnapshotEditor {
   /**
    * Ensures that there is a ParameterizedValueSnapshot for the given field.
    */
-  _ensureParameterizedValueSnapshot(containerId: NodeId, path: PathPart[], field: DynamicFieldWithArgs, variables: object) {
+  _ensureParameterizedValueSnapshot(containerId: NodeId, path: PathPart[], field: DynamicFieldWithArgs, variables: JsonObject) {
     const args = expandFieldArguments(field.args, variables);
     const fieldId = nodeIdForParameterizedValue(containerId, path, args);
 
@@ -471,7 +471,7 @@ export class SnapshotEditor {
 /**
  * Generate a stable id for a parameterized value.
  */
-export function nodeIdForParameterizedValue(containerId: NodeId, path: PathPart[], args: object | undefined) {
+export function nodeIdForParameterizedValue(containerId: NodeId, path: PathPart[], args?: JsonObject) {
   return `${containerId}❖${JSON.stringify(path)}❖${JSON.stringify(args)}`;
 }
 

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -377,8 +377,10 @@ export class SnapshotEditor {
       if (newSnapshot === undefined) {
         delete snapshots[id];
       } else {
-        // _newNodes only contains EntityNode
-        if (entityTransformer) entityTransformer(this._newNodes[id]!.node);
+        if (entityTransformer) {
+          const { node } = this._newNodes[id] as EntitySnapshot;
+          if (node) entityTransformer(node);
+        }
         snapshots[id] = newSnapshot;
       }
     }

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -1,4 +1,4 @@
-import { PathPart } from '../primitive';
+import { JsonObject, JsonValue, PathPart } from '../primitive';
 import { expandFieldArguments, DynamicField, DynamicFieldMap } from '../DynamicField';
 import { nodeIdForParameterizedValue } from './SnapshotEditor';
 import { walkOperation } from '../util';
@@ -9,7 +9,7 @@ import { isObject } from '../util';
 
 export interface QueryResult {
   /** The value of the root requested by a query. */
-  result: any;
+  result?: JsonObject;
   /** Whether the query's selection set was satisfied. */
   complete: boolean;
 }
@@ -55,7 +55,7 @@ export function read(context: CacheContext, query: Query, snapshot: GraphSnapsho
 
 class OverlayWalkNode {
   constructor(
-    public readonly value: any,
+    public readonly value: JsonObject,
     public readonly containerId: NodeId,
     public readonly fieldMap: DynamicFieldMap,
     public readonly path: PathPart[],
@@ -75,8 +75,8 @@ export function _walkAndOverlayDynamicValues(
   context: CacheContext,
   snapshot: GraphSnapshot,
   fields: DynamicFieldMap,
-  result: any,
-): any {
+  result: JsonObject,
+): JsonObject {
   // Corner case: We stop walking once we reach a parameterized field with no
   // snapshot, but we should also pre-emptively stop walking if there are no
 
@@ -159,10 +159,9 @@ export function _walkAndOverlayDynamicValues(
   return newResult;
 }
 
-function _wrapValue(value: any): any {
+function _wrapValue(value: JsonValue): any {
   if (value === undefined) return {};
   if (Array.isArray(value)) return [...value];
-  // TODO: Switch back to Object.create() once we fix shit
   if (isObject(value)) return { ...value };
   return value;
 }
@@ -173,7 +172,7 @@ function _wrapValue(value: any): any {
 export function _visitSelection(
   query: ParsedQuery,
   context: CacheContext,
-  result: any,
+  result?: JsonObject,
   includeNodeIds?: true,
 ): { complete: boolean, nodeIds?: Set<NodeId> } {
   let complete = true;

--- a/src/operations/write.ts
+++ b/src/operations/write.ts
@@ -1,5 +1,6 @@
 import { CacheContext } from '../context';
 import { GraphSnapshot } from '../GraphSnapshot';
+import { JsonObject } from '../primitive';
 import { Query } from '../schema';
 
 import { EditedSnapshot, SnapshotEditor } from './SnapshotEditor';
@@ -10,7 +11,7 @@ import { EditedSnapshot, SnapshotEditor } from './SnapshotEditor';
  * Performs the minimal set of edits to generate new immutable versions of each
  * node, while preserving immutability of the parent snapshot.
  */
-export function write(context: CacheContext, snapshot: GraphSnapshot, query: Query, payload: object): EditedSnapshot {
+export function write(context: CacheContext, snapshot: GraphSnapshot, query: Query, payload: JsonObject): EditedSnapshot {
   // We _could_ go purely functional with the editor, but it's honestly pretty
   // convenient to follow the builder function instead - it'd end up passing
   // around a context object anyway.

--- a/src/primitive.ts
+++ b/src/primitive.ts
@@ -48,3 +48,5 @@ export interface NestedObject<TValue> { [key: string]: NestedValue<TValue>; }
 
 export type JsonScalar = null | boolean | number | string;
 export type JsonValue = NestedValue<JsonScalar>;
+export type JsonObject = NestedObject<JsonScalar>;
+export type JsonArray = NestedArray<JsonScalar>;

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -59,5 +59,5 @@ export interface ParsedQuery {
  */
 export interface QuerySnapshot {
   query: Query;
-  payload: any;
+  payload?: JsonObject;
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,6 +1,7 @@
 import { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
 
 import { QueryInfo } from './context';
+import { JsonObject } from './primitive';
 
 /**
  * Change ids track diffs to the store that may eventually be rolled back.
@@ -38,7 +39,7 @@ export interface Query {
   /** A parsed GraphQL document, declaring an operation to execute. */
   readonly document: DocumentNode;
   /** Any variables used by parameterized fields within the selection set. */
-  readonly variables?: object;
+  readonly variables?: JsonObject;
 }
 
 /**
@@ -50,7 +51,7 @@ export interface ParsedQuery {
   /** A parsed GraphQL document, declaring an operation to execute. */
   readonly info: QueryInfo;
   /** Any variables used by parameterized fields within the selection set. */
-  readonly variables?: object;
+  readonly variables?: JsonObject;
 }
 
 /**

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -53,7 +53,7 @@ export function variableDefaultsInOperation(operation: OperationDefinitionNode):
       if (definition.type.kind === 'NonNullType') continue; // Required.
 
       const { defaultValue } = definition;
-      defaults[definition.variable.name.value] = isObject(defaultValue) ? valueFromNode(defaultValue) : null;
+      defaults[definition.variable.name.value] = isObject(defaultValue) ? valueFromNode(defaultValue as ValueNode) : null;
     }
   }
 

--- a/src/util/primitive.ts
+++ b/src/util/primitive.ts
@@ -1,9 +1,9 @@
-import { scalar } from '../primitive';
+import { JsonObject, scalar } from '../primitive';
 
 export function isScalar(value: any): value is scalar {
   return typeof value !== 'object' || value === null;
 }
 
-export function isObject(value: any): value is object {
+export function isObject(value: any): value is JsonObject {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }

--- a/src/util/tree.ts
+++ b/src/util/tree.ts
@@ -11,7 +11,7 @@ import { // eslint-disable-line import/no-extraneous-dependencies, import/no-unr
 } from 'graphql';
 
 import { DynamicField, DynamicFieldMap } from '../DynamicField';
-import { PathPart } from '../primitive';
+import { JsonObject, JsonValue, PathPart } from '../primitive';
 
 import { fragmentMapForDocument, getOperationOrDie } from './ast';
 
@@ -22,9 +22,9 @@ import { fragmentMapForDocument, getOperationOrDie } from './ast';
 class PayloadWalkNode {
   constructor(
     /** The value of the payload at this location in the walk. */
-    public readonly payload: any,
+    public readonly payload: JsonValue,
     /** The value of the current node at this location in the walk. */
-    public readonly node: any,
+    public readonly node: JsonValue | undefined,
     /** The value of the field map at this location in the walk. */
     public readonly fieldMap: DynamicFieldMap | DynamicField | undefined,
     /** The depth of the node (allows us to set the path correctly). */
@@ -40,8 +40,8 @@ class PayloadWalkNode {
  */
 export type PayloadVisitor = (
   path: PathPart[],
-  payloadValue: any,
-  nodeValue: any,
+  payloadValue: JsonValue,
+  nodeValue: JsonValue | undefined,
   dynamicField: DynamicField | DynamicFieldMap | undefined,
 ) => boolean;
 
@@ -59,8 +59,8 @@ export type PayloadVisitor = (
  * to the values inside the (homogeneous) array.
  */
 export function walkPayload(
-  payload: any,
-  node: any,
+  payload: JsonValue,
+  node: JsonValue | undefined,
   rootFieldMap: DynamicField | DynamicFieldMap | undefined,
   visitRoot: boolean,
   visitor: PayloadVisitor,
@@ -138,19 +138,19 @@ export function walkPayload(
 class OperationWalkNode {
   constructor(
     public readonly selectionSet: SelectionSetNode,
-    public readonly parent: any,
+    public readonly parent?: JsonValue,
   ) {}
 }
 
 /**
  * Returning true indicates that the walk should STOP.
  */
-export type OperationVisitor = (parent: any, fields: FieldNode[]) => boolean;
+export type OperationVisitor = (parent: JsonValue | undefined, fields: FieldNode[]) => boolean;
 
 /**
  *
  */
-export function walkOperation(document: DocumentNode, result: any, visitor: OperationVisitor) {
+export function walkOperation(document: DocumentNode, result: JsonObject | undefined, visitor: OperationVisitor) {
   const operation = getOperationOrDie(document);
   const fragmentMap = fragmentMapForDocument(document);
 

--- a/test/helpers/graphql.ts
+++ b/test/helpers/graphql.ts
@@ -1,11 +1,12 @@
 import gql from 'graphql-tag';
 
+import { JsonObject } from '../../src/primitive';
 import { NodeId, Query, StaticNodeId } from '../../src/schema';
 
 /**
  * Constructs a Query from a gql document.
  */
-export function query(gqlString: string, variables?: object, rootId?: NodeId): Query {
+export function query(gqlString: string, variables?: JsonObject, rootId?: NodeId): Query {
   return {
     rootId: rootId || StaticNodeId.QueryRoot,
     document: gql(gqlString),

--- a/test/unit/context/CacheContext/entityIdForNode.ts
+++ b/test/unit/context/CacheContext/entityIdForNode.ts
@@ -21,21 +21,21 @@ describe(`context.CacheContext`, () => {
         expect(context.entityIdForNode({ id: true })).to.eq(undefined);
         expect(context.entityIdForNode({ id: false })).to.eq(undefined);
         expect(context.entityIdForNode({ id: null })).to.eq(undefined);
-        expect(context.entityIdForNode({ id: undefined })).to.eq(undefined);
-        expect(context.entityIdForNode({ id: Symbol.iterator })).to.eq(undefined);
+        expect(context.entityIdForNode({ id: undefined } as any)).to.eq(undefined);
+        expect(context.entityIdForNode({ id: Symbol.iterator } as any)).to.eq(undefined);
         expect(context.entityIdForNode({ id: {} })).to.eq(undefined);
-        expect(context.entityIdForNode({ id() {} })).to.eq(undefined);
+        expect(context.entityIdForNode({ id() {} } as any)).to.eq(undefined);
         expect(context.entityIdForNode({ id: { id: 'hi' } })).to.eq(undefined);
         expect(context.entityIdForNode({ id: [] })).to.eq(undefined);
         expect(context.entityIdForNode({ id: ['hi'] })).to.eq(undefined);
       });
 
       it(`ignores nodes that lack an id property`, () => {
-        expect(context.entityIdForNode(undefined)).to.eq(undefined);
+        expect(context.entityIdForNode(undefined as any)).to.eq(undefined);
         expect(context.entityIdForNode({})).to.eq(undefined);
         expect(context.entityIdForNode({ idd: 'hi' })).to.eq(undefined);
-        expect(context.entityIdForNode([])).to.eq(undefined);
-        expect(context.entityIdForNode(() => {})).to.eq(undefined);
+        expect(context.entityIdForNode([] as any)).to.eq(undefined);
+        expect(context.entityIdForNode((() => {}) as any)).to.eq(undefined);
       });
 
     });

--- a/test/unit/context/CacheContext/entityTransformation.ts
+++ b/test/unit/context/CacheContext/entityTransformation.ts
@@ -55,8 +55,8 @@ describe(`context.CacheContext`, () => {
 
       it(`get information through helper methods`, () => {
         const { result } = read(entityTransformerContext, viewerQuery, snapshot);
-        const name = result.viewer.getName();
-        const id = result.viewer.getId();
+        const name = (result as any).viewer.getName();
+        const id = (result as any).viewer.getId();
         expect(name).to.eq('Bob');
         expect(id).to.eq('0');
       });
@@ -164,10 +164,10 @@ describe(`context.CacheContext`, () => {
 
       it(`get information through helper methods`, () => {
         const { result } = read(entityTransformerContext, viewerQuery, snapshot);
-        expect(result.user.getName()).to.eq('Bob');
-        expect(result.user.getId()).to.eq('0');
-        expect(result.user.getJustPhoneNumber()).to.eq(1234);
-        expect(result.user.getCity()).to.eq('AA');
+        expect((result as any).user.getName()).to.eq('Bob');
+        expect((result as any).user.getId()).to.eq('0');
+        expect((result as any).user.getJustPhoneNumber()).to.eq(1234);
+        expect((result as any).user.getCity()).to.eq('AA');
       });
 
       it(`check helper methods exists`, () => {
@@ -280,10 +280,10 @@ describe(`context.CacheContext`, () => {
 
       it(`get information through helper methods`, () => {
         const { result } = read(entityTransformerContext, viewerQuery, snapshot);
-        expect(result.user.getName()).to.eq('Bob');
-        expect(result.user.getId()).to.eq('0');
-        expect(result.user.getJustPhoneNumber()).to.eq(1234);
-        expect(result.user.getCity()).to.eq('AA');
+        expect((result as any).user.getName()).to.eq('Bob');
+        expect((result as any).user.getId()).to.eq('0');
+        expect((result as any).user.getJustPhoneNumber()).to.eq(1234);
+        expect((result as any).user.getCity()).to.eq('AA');
       });
 
       it(`check helper methods exists`, () => {

--- a/test/unit/context/CacheContext/entityTransformation.ts
+++ b/test/unit/context/CacheContext/entityTransformation.ts
@@ -1,3 +1,4 @@
+import { JsonObject } from '../../../../src/primitive';
 import * as _ from 'lodash';
 
 import { CacheContext } from '../../../../src/context';
@@ -31,7 +32,7 @@ describe(`context.CacheContext`, () => {
 
         entityTransformerContext = new CacheContext({
           addTypename: true,
-          entityTransformer: (node: object): void => {
+          entityTransformer: (node: JsonObject): void => {
             mixinHelperMethods(node, {
               getName(this: { id: string, name: string }) {
                 return this.name;
@@ -116,7 +117,7 @@ describe(`context.CacheContext`, () => {
 
         entityTransformerContext = new CacheContext({
           addTypename: true,
-          entityTransformer: (node: object): void => {
+          entityTransformer: (node: JsonObject): void => {
             mixinHelperMethods(node, {
               getName(this: User) {
                 return this.name;
@@ -232,7 +233,7 @@ describe(`context.CacheContext`, () => {
 
         entityTransformerContext = new CacheContext({
           addTypename: true,
-          entityTransformer: (node: object): void => {
+          entityTransformer: (node: JsonObject): void => {
             mixinHelperMethods(node, {
               getName(this: User) {
                 return this.name;
@@ -310,7 +311,7 @@ describe(`context.CacheContext`, () => {
 
         entityTransformerContext = new CacheContext({
           addTypename: true,
-          entityTransformer: (node: object): void => {
+          entityTransformer: (node: JsonObject): void => {
             Object.freeze(node);
           },
         });

--- a/test/unit/context/CacheContext/entityTransformation.ts
+++ b/test/unit/context/CacheContext/entityTransformation.ts
@@ -1,10 +1,10 @@
-import { JsonObject } from '../../../../src/primitive';
 import * as _ from 'lodash';
 
 import { CacheContext } from '../../../../src/context';
 import { GraphSnapshot } from '../../../../src/GraphSnapshot';
 import { read } from '../../../../src/operations/read';
 import { write } from '../../../../src/operations/write';
+import { JsonObject } from '../../../../src/primitive';
 import { Query, StaticNodeId } from '../../../../src/schema';
 import { query } from '../../../helpers';
 

--- a/test/unit/operations/read/cyclicReferences.ts
+++ b/test/unit/operations/read/cyclicReferences.ts
@@ -45,7 +45,7 @@ describe(`operations.read`, () => {
 
       it(`can be read`, () => {
         const { result } = read(context, cyclicQuery, snapshot);
-        const foo = result.foo;
+        const foo = (result as any).foo;
         const bar = foo.bar;
 
         expect(foo.id).to.eq(1);
@@ -102,7 +102,7 @@ describe(`operations.read`, () => {
 
       it(`can be read`, () => {
         const { result } = read(context, cyclicQuery, snapshot);
-        const foo = result.foo;
+        const foo = (result as any).foo;
         const bar = foo.bar;
 
         expect(foo.id).to.eq(1);

--- a/test/unit/operations/write/editValues.ts
+++ b/test/unit/operations/write/editValues.ts
@@ -4,6 +4,7 @@ import { CacheContext } from '../../../../src/context';
 import { GraphSnapshot } from '../../../../src/GraphSnapshot';
 import { EntitySnapshot } from '../../../../src/nodes';
 import { write } from '../../../../src/operations/write';
+import { JsonArray } from '../../../../src/primitive';
 import { NodeId, Query, StaticNodeId } from '../../../../src/schema';
 import { query } from '../../../helpers';
 
@@ -368,7 +369,7 @@ describe(`operations.write`, () => {
           { id: 3, name: 'Three' },
           { id: 4, name: 'Four' },
           undefined,
-        ],
+        ] as JsonArray,
       }).snapshot;
 
       expect(updated.getNodeSnapshot(QueryRootId)!.outbound).to.have.deep.members([


### PR DESCRIPTION
We should be handling JSON-serializable types…

* …when given a payload from the server
* …from Apollo when writing values
* …when storing values
* …when returning values