### PR TITLE
Expand variables at query parse time, and support for optional/default arguments

### DIFF
--- a/src/DynamicField.ts
+++ b/src/DynamicField.ts
@@ -23,10 +23,10 @@ export class DynamicField<TArgTypes extends JsonAndArgs, TChildArgTypes extends 
     public readonly children?: DynamicFieldMap<TChildArgTypes>,
   ) {}
 }
+export interface DynamicFieldWithVariables extends DynamicField<JsonAndArgs, JsonAndArgs> {}
 
 export namespace DynamicField {
   export interface WithoutVariables extends DynamicField<JsonScalar, JsonScalar> {}
-  export interface WithVariables extends DynamicField<JsonAndArgs, JsonAndArgs> {}
   export interface WithArgs extends WithoutVariables {
     readonly args: NestedObject<JsonScalar>;
   }
@@ -39,10 +39,10 @@ export namespace DynamicField {
 export interface DynamicFieldMap<TArgTypes extends JsonAndArgs> {
   [Key: string]: DynamicFieldMap<TArgTypes> | DynamicField<TArgTypes, TArgTypes>;
 }
+export interface DynamicFieldMapWithVariables extends DynamicFieldMap<JsonAndArgs> {}
 
 export namespace DynamicFieldMap {
   export interface WithoutVariables extends DynamicFieldMap<JsonScalar> {}
-  export interface WithVariables extends DynamicFieldMap<JsonAndArgs> {}
 }
 
 // TODO: Can we remove this?
@@ -78,7 +78,7 @@ function _buildDynamicFieldMap(
   variables: Set<string>,
   fragments: FragmentMap,
   selectionSet?: SelectionSetNode,
-): DynamicFieldMap.WithVariables | undefined {
+): DynamicFieldMapWithVariables | undefined {
   if (!selectionSet) return undefined;
 
   let fieldMap;
@@ -101,7 +101,7 @@ function _buildDynamicFieldMap(
       // saves a bit of overhead, and allows us to more cleanly reason about
       // where dynamic fields are in the selection.
       const currentKey: string = selection.alias ? selection.alias.value : selection.name.value;
-      let currentField: DynamicField.WithVariables | DynamicFieldMap.WithVariables | undefined;
+      let currentField: DynamicFieldWithVariables | DynamicFieldMapWithVariables | undefined;
       let parameterizedArguments: FieldArguments | undefined;
 
       if (selection.kind === 'Field' && selection.arguments && selection.arguments.length) {
@@ -164,7 +164,7 @@ export function isDynamicFieldWithArgs(field: any): field is DynamicField.WithAr
  * This requires that all variables used are provided in `variables`.
  */
 export function expandVariables(
-  map: DynamicFieldMap.WithVariables | undefined,
+  map: DynamicFieldMapWithVariables | undefined,
   variables: JsonObject | undefined,
 ): DynamicFieldMap.WithoutVariables | undefined {
   if (!map) return undefined;

--- a/src/DynamicField.ts
+++ b/src/DynamicField.ts
@@ -27,9 +27,8 @@ export class DynamicField<TArgTypes extends JsonAndArgs, TChildArgTypes extends 
 export namespace DynamicField {
   export interface WithoutVariables extends DynamicField<JsonScalar, JsonScalar> {}
   export interface WithVariables extends DynamicField<JsonAndArgs, JsonAndArgs> {}
-  // TODO: should extend WithoutVariables.
-  export interface WithArgs extends WithVariables {
-    readonly args: NestedObject<JsonAndArgs>;
+  export interface WithArgs extends WithoutVariables {
+    readonly args: NestedObject<JsonScalar>;
   }
 }
 

--- a/src/DynamicField.ts
+++ b/src/DynamicField.ts
@@ -24,12 +24,12 @@ export class DynamicField<TArgTypes = JsonScalar, TChildArgTypes = JsonScalar> {
   ) {}
 }
 export interface DynamicFieldWithVariables extends DynamicField<JsonAndArgs, JsonAndArgs> {}
+export interface DynamicFieldWithArgs extends DynamicField {
+  readonly args: NestedObject<JsonScalar>;
+}
 
 export namespace DynamicField {
   export interface WithoutVariables extends DynamicField {}
-  export interface WithArgs extends DynamicField {
-    readonly args: NestedObject<JsonScalar>;
-  }
 }
 
 /**
@@ -153,7 +153,7 @@ function _valueFromNode(variables: Set<string>, node: ValueNode): JsonValue {
 /**
  * Whether the field is a DynamicFieldWithParameterizedArguments
  */
-export function isDynamicFieldWithArgs(field: any): field is DynamicField.WithArgs {
+export function isDynamicFieldWithArgs(field: any): field is DynamicFieldWithArgs {
   return !!(field instanceof DynamicField && field.args);
 }
 

--- a/src/DynamicField.ts
+++ b/src/DynamicField.ts
@@ -13,7 +13,7 @@ export type JsonAndArgs = JsonScalar | VariableArgument;
  * Represent dynamic information: alias, parameterized arguments, directives
  * (if existed) of NodeSnapshot in GraphSnapshot.
  */
-export class DynamicField<TArgTypes extends JsonAndArgs, TChildArgTypes extends JsonAndArgs> {
+export class DynamicField<TArgTypes = JsonScalar, TChildArgTypes = JsonScalar> {
   constructor(
     /** The map of arguments and their static or variable values. */
     public readonly args?: NestedObject<TArgTypes>,
@@ -26,8 +26,8 @@ export class DynamicField<TArgTypes extends JsonAndArgs, TChildArgTypes extends 
 export interface DynamicFieldWithVariables extends DynamicField<JsonAndArgs, JsonAndArgs> {}
 
 export namespace DynamicField {
-  export interface WithoutVariables extends DynamicField<JsonScalar, JsonScalar> {}
-  export interface WithArgs extends WithoutVariables {
+  export interface WithoutVariables extends DynamicField {}
+  export interface WithArgs extends DynamicField {
     readonly args: NestedObject<JsonScalar>;
   }
 }
@@ -36,13 +36,13 @@ export namespace DynamicField {
  * A recursive map where the keys indicate the path to any field in a result set
  * that contain a dynamic field.
  */
-export interface DynamicFieldMap<TArgTypes extends JsonAndArgs> {
+export interface DynamicFieldMap<TArgTypes = JsonScalar> {
   [Key: string]: DynamicFieldMap<TArgTypes> | DynamicField<TArgTypes, TArgTypes>;
 }
 export interface DynamicFieldMapWithVariables extends DynamicFieldMap<JsonAndArgs> {}
 
 export namespace DynamicFieldMap {
-  export interface WithoutVariables extends DynamicFieldMap<JsonScalar> {}
+  export interface WithoutVariables extends DynamicFieldMap {}
 }
 
 // TODO: Can we remove this?

--- a/src/DynamicField.ts
+++ b/src/DynamicField.ts
@@ -37,9 +37,6 @@ export interface DynamicFieldMap<TArgTypes = JsonScalar> {
 }
 export interface DynamicFieldMapWithVariables extends DynamicFieldMap<JsonAndArgs> {}
 
-// TODO: Can we remove this?
-export type FieldArguments = NestedObject<JsonAndArgs>;
-
 /**
  * Represents the location a variable should be used as an argument to a
  * parameterized field.
@@ -94,7 +91,7 @@ function _buildDynamicFieldMap(
       // where dynamic fields are in the selection.
       const currentKey: string = selection.alias ? selection.alias.value : selection.name.value;
       let currentField: DynamicFieldWithVariables | DynamicFieldMapWithVariables | undefined;
-      let parameterizedArguments: FieldArguments | undefined;
+      let parameterizedArguments: NestedObject<JsonAndArgs> | undefined;
 
       if (selection.kind === 'Field' && selection.arguments && selection.arguments.length) {
         parameterizedArguments = _buildFieldArgs(variables, selection.arguments);
@@ -122,7 +119,7 @@ function _buildDynamicFieldMap(
 /**
  * Build the map of arguments to their natural JS values (or variables).
  */
-function _buildFieldArgs(variables: Set<string>, argumentsNode: ArgumentNode[]): FieldArguments {
+function _buildFieldArgs(variables: Set<string>, argumentsNode: ArgumentNode[]): NestedObject<JsonAndArgs> {
   const args = {};
   for (const arg of argumentsNode) {
     // Mapped name of argument to it JS value

--- a/src/DynamicField.ts
+++ b/src/DynamicField.ts
@@ -28,10 +28,6 @@ export interface DynamicFieldWithArgs extends DynamicField {
   readonly args: NestedObject<JsonScalar>;
 }
 
-export namespace DynamicField {
-  export interface WithoutVariables extends DynamicField {}
-}
-
 /**
  * A recursive map where the keys indicate the path to any field in a result set
  * that contain a dynamic field.
@@ -40,10 +36,6 @@ export interface DynamicFieldMap<TArgTypes = JsonScalar> {
   [Key: string]: DynamicFieldMap<TArgTypes> | DynamicField<TArgTypes, TArgTypes>;
 }
 export interface DynamicFieldMapWithVariables extends DynamicFieldMap<JsonAndArgs> {}
-
-export namespace DynamicFieldMap {
-  export interface WithoutVariables extends DynamicFieldMap {}
-}
 
 // TODO: Can we remove this?
 export type FieldArguments = NestedObject<JsonAndArgs>;
@@ -166,7 +158,7 @@ export function isDynamicFieldWithArgs(field: any): field is DynamicFieldWithArg
 export function expandVariables(
   map: DynamicFieldMapWithVariables | undefined,
   variables: JsonObject | undefined,
-): DynamicFieldMap.WithoutVariables | undefined {
+): DynamicFieldMap | undefined {
   if (!map) return undefined;
 
   const newMap = {};

--- a/src/context/CacheContext.ts
+++ b/src/context/CacheContext.ts
@@ -1,7 +1,7 @@
-import { expandVariables } from '../DynamicField';
 import { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
 import lodashIsEqual = require('lodash.isequal');
 
+import { expandVariables } from '../DynamicField';
 import { JsonObject } from '../primitive';
 import { EntityId, ParsedQuery, Query } from '../schema';
 import { addTypenameToDocument, isObject } from '../util';

--- a/src/context/CacheContext.ts
+++ b/src/context/CacheContext.ts
@@ -103,10 +103,11 @@ export class CacheContext {
     }
 
     const info = this._queryInfo(query.document);
+    const fullVariables = { ...info.variableDefaults, ...query.variables } as JsonObject;
     const parsedQuery = {
       info,
       rootId: query.rootId,
-      dynamicFieldMap: expandVariables(info.dynamicFieldMap, query.variables),
+      dynamicFieldMap: expandVariables(info.dynamicFieldMap, fullVariables),
       variables: query.variables,
     };
     parsedQueries.push(parsedQuery);

--- a/src/context/CacheContext.ts
+++ b/src/context/CacheContext.ts
@@ -1,3 +1,4 @@
+import { expandVariables } from '../DynamicField';
 import { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
 import lodashIsEqual = require('lodash.isequal');
 
@@ -101,10 +102,11 @@ export class CacheContext {
       return parsedQuery;
     }
 
-    // New query.
+    const info = this._queryInfo(query.document);
     const parsedQuery = {
+      info,
       rootId: query.rootId,
-      info: this._queryInfo(query.document),
+      dynamicFieldMap: expandVariables(info.dynamicFieldMap, query.variables),
       variables: query.variables,
     };
     parsedQueries.push(parsedQuery);

--- a/src/context/QueryInfo.ts
+++ b/src/context/QueryInfo.ts
@@ -36,7 +36,7 @@ export class QueryInfo {
    * The field map for the document, if there are any dynamic features: alias,
    * parameterized arguments, directive
    */
-  public readonly dynamicFieldMap?: DynamicFieldMap;
+  public readonly dynamicFieldMap?: DynamicFieldMap.WithVariables;
   /** Variables used within this query. */
   public readonly variables: Set<string>;
   /**

--- a/src/context/QueryInfo.ts
+++ b/src/context/QueryInfo.ts
@@ -4,7 +4,7 @@ import { // eslint-disable-line import/no-extraneous-dependencies, import/no-unr
   OperationTypeNode,
 } from 'graphql';
 
-import { compileDynamicFields, DynamicFieldMap, JsonAndArgs } from '../DynamicField';
+import { compileDynamicFields, DynamicFieldMapWithVariables } from '../DynamicField';
 import { JsonValue } from '../primitive';
 import {
   FragmentMap,
@@ -36,7 +36,7 @@ export class QueryInfo {
    * The field map for the document, if there are any dynamic features: alias,
    * parameterized arguments, directive
    */
-  public readonly dynamicFieldMap?: DynamicFieldMap<JsonAndArgs>;
+  public readonly dynamicFieldMap?: DynamicFieldMapWithVariables;
   /** Variables used within this query. */
   public readonly variables: Set<string>;
   /**

--- a/src/context/QueryInfo.ts
+++ b/src/context/QueryInfo.ts
@@ -4,7 +4,7 @@ import { // eslint-disable-line import/no-extraneous-dependencies, import/no-unr
   OperationTypeNode,
 } from 'graphql';
 
-import { DynamicFieldMap, compileDynamicFields } from '../DynamicField';
+import { compileDynamicFields, DynamicFieldMap, JsonAndArgs } from '../DynamicField';
 import { JsonValue } from '../primitive';
 import {
   FragmentMap,
@@ -36,7 +36,7 @@ export class QueryInfo {
    * The field map for the document, if there are any dynamic features: alias,
    * parameterized arguments, directive
    */
-  public readonly dynamicFieldMap?: DynamicFieldMap.WithVariables;
+  public readonly dynamicFieldMap?: DynamicFieldMap<JsonAndArgs>;
   /** Variables used within this query. */
   public readonly variables: Set<string>;
   /**

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -2,7 +2,6 @@ import { CacheContext } from '../context';
 import {
   DynamicField,
   DynamicFieldMap,
-  DynamicFieldWithArgs,
   expandFieldArguments,
   isDynamicFieldWithArgs,
 } from '../DynamicField';
@@ -36,7 +35,7 @@ interface MergeQueueItem {
   containerId: NodeId;
   containerPayload: JsonObject;
   visitRoot: boolean;
-  fields: DynamicField | DynamicFieldMap | undefined;
+  fields: DynamicField.WithVariables | DynamicFieldMap.WithVariables | undefined;
 }
 
 /**
@@ -451,7 +450,7 @@ export class SnapshotEditor {
   /**
    * Ensures that there is a ParameterizedValueSnapshot for the given field.
    */
-  _ensureParameterizedValueSnapshot(containerId: NodeId, path: PathPart[], field: DynamicFieldWithArgs, variables: JsonObject) {
+  _ensureParameterizedValueSnapshot(containerId: NodeId, path: PathPart[], field: DynamicField.WithArgs, variables: JsonObject) {
     const args = expandFieldArguments(field.args, variables);
     const fieldId = nodeIdForParameterizedValue(containerId, path, args);
 

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -30,7 +30,7 @@ interface MergeQueueItem {
   containerId: NodeId;
   containerPayload: JsonObject;
   visitRoot: boolean;
-  fields: DynamicField.WithoutVariables | DynamicFieldMap.WithoutVariables | undefined;
+  fields: DynamicField | DynamicFieldMap | undefined;
 }
 
 /**

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -1,5 +1,5 @@
 import { CacheContext } from '../context';
-import { DynamicField, DynamicFieldMap, isDynamicFieldWithArgs } from '../DynamicField';
+import { DynamicField, DynamicFieldWithArgs, DynamicFieldMap, isDynamicFieldWithArgs } from '../DynamicField';
 import { GraphSnapshot } from '../GraphSnapshot';
 import { EntitySnapshot, NodeSnapshot, ParameterizedValueSnapshot, cloneNodeSnapshot } from '../nodes';
 import { JsonObject, PathPart } from '../primitive';
@@ -444,7 +444,7 @@ export class SnapshotEditor {
   /**
    * Ensures that there is a ParameterizedValueSnapshot for the given field.
    */
-  _ensureParameterizedValueSnapshot(containerId: NodeId, path: PathPart[], field: DynamicField.WithArgs, variables: JsonObject) {
+  _ensureParameterizedValueSnapshot(containerId: NodeId, path: PathPart[], field: DynamicFieldWithArgs, variables: JsonObject) {
     const fieldId = nodeIdForParameterizedValue(containerId, path, field.args);
 
     // We're careful to not edit the container unless we absolutely have to.

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -57,7 +57,7 @@ class OverlayWalkNode {
   constructor(
     public readonly value: JsonObject,
     public readonly containerId: NodeId,
-    public readonly fieldMap: DynamicFieldMap.WithoutVariables,
+    public readonly fieldMap: DynamicFieldMap,
     public readonly path: PathPart[],
   ) {}
 }
@@ -74,7 +74,7 @@ export function _walkAndOverlayDynamicValues(
   query: ParsedQuery,
   context: CacheContext,
   snapshot: GraphSnapshot,
-  fields: DynamicFieldMap.WithoutVariables,
+  fields: DynamicFieldMap,
   result: JsonObject,
 ): JsonObject {
   // Corner case: We stop walking once we reach a parameterized field with no
@@ -111,7 +111,7 @@ export function _walkAndOverlayDynamicValues(
     }
 
     for (const key in fieldMap) {
-      let field: DynamicFieldMap.WithoutVariables | DynamicField.WithoutVariables | undefined = fieldMap[key];
+      let field: DynamicFieldMap | DynamicField | undefined = fieldMap[key];
       let child, childId;
       let fieldName = key;
 
@@ -140,12 +140,12 @@ export function _walkAndOverlayDynamicValues(
           for (let i = child.length - 1; i >= 0; i--) {
             if (child[i] === null) continue;
             child[i] = _wrapValue(child[i]);
-            queue.push(new OverlayWalkNode(child[i], containerId, field as DynamicFieldMap.WithoutVariables, [...path, fieldName, i]));
+            queue.push(new OverlayWalkNode(child[i], containerId, field as DynamicFieldMap, [...path, fieldName, i]));
           }
 
         } else {
           child = _wrapValue(child);
-          queue.push(new OverlayWalkNode(child, containerId, field as DynamicFieldMap.WithoutVariables, [...path, fieldName]))
+          queue.push(new OverlayWalkNode(child, containerId, field as DynamicFieldMap, [...path, fieldName]))
         }
       }
 

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -57,7 +57,7 @@ class OverlayWalkNode {
   constructor(
     public readonly value: JsonObject,
     public readonly containerId: NodeId,
-    public readonly fieldMap: DynamicFieldMap,
+    public readonly fieldMap: DynamicFieldMap.WithVariables,
     public readonly path: PathPart[],
   ) {}
 }
@@ -74,7 +74,7 @@ export function _walkAndOverlayDynamicValues(
   query: ParsedQuery,
   context: CacheContext,
   snapshot: GraphSnapshot,
-  fields: DynamicFieldMap,
+  fields: DynamicFieldMap.WithVariables,
   result: JsonObject,
 ): JsonObject {
   // Corner case: We stop walking once we reach a parameterized field with no
@@ -112,7 +112,7 @@ export function _walkAndOverlayDynamicValues(
     }
 
     for (const key in fieldMap) {
-      let field: DynamicFieldMap | DynamicField | undefined = fieldMap[key];
+      let field: DynamicFieldMap.WithVariables | DynamicField.WithVariables | undefined = fieldMap[key];
       let child, childId;
       let fieldName = key;
 
@@ -142,12 +142,12 @@ export function _walkAndOverlayDynamicValues(
           for (let i = child.length - 1; i >= 0; i--) {
             if (child[i] === null) continue;
             child[i] = _wrapValue(child[i]);
-            queue.push(new OverlayWalkNode(child[i], containerId, field as DynamicFieldMap, [...path, fieldName, i]));
+            queue.push(new OverlayWalkNode(child[i], containerId, field as DynamicFieldMap.WithVariables, [...path, fieldName, i]));
           }
 
         } else {
           child = _wrapValue(child);
-          queue.push(new OverlayWalkNode(child, containerId, field as DynamicFieldMap, [...path, fieldName]))
+          queue.push(new OverlayWalkNode(child, containerId, field as DynamicFieldMap.WithVariables, [...path, fieldName]))
         }
       }
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,7 +1,7 @@
-import { DynamicFieldMap } from './DynamicField';
 import { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
 
 import { QueryInfo } from './context';
+import { DynamicFieldMap } from './DynamicField';
 import { JsonObject } from './primitive';
 
 /**
@@ -52,7 +52,7 @@ export interface ParsedQuery {
   /** A parsed GraphQL document, declaring an operation to execute. */
   readonly info: QueryInfo;
   /** The dynamic field map for the query, with variables substituted in. */
-  readonly dynamicFieldMap?: DynamicFieldMap.WithoutVariables;
+  readonly dynamicFieldMap?: DynamicFieldMap;
   /** Any variables used by parameterized fields within the selection set. */
   readonly variables?: JsonObject;
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,3 +1,4 @@
+import { DynamicFieldMap } from './DynamicField';
 import { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies, import/no-unresolved
 
 import { QueryInfo } from './context';
@@ -50,6 +51,8 @@ export interface ParsedQuery {
   readonly rootId: NodeId;
   /** A parsed GraphQL document, declaring an operation to execute. */
   readonly info: QueryInfo;
+  /** The dynamic field map for the query, with variables substituted in. */
+  readonly dynamicFieldMap?: DynamicFieldMap.WithoutVariables;
   /** Any variables used by parameterized fields within the selection set. */
   readonly variables?: JsonObject;
 }

--- a/src/util/tree.ts
+++ b/src/util/tree.ts
@@ -26,7 +26,7 @@ class PayloadWalkNode {
     /** The value of the current node at this location in the walk. */
     public readonly node: JsonValue | undefined,
     /** The value of the field map at this location in the walk. */
-    public readonly fieldMap: DynamicFieldMap | DynamicField | undefined,
+    public readonly fieldMap: DynamicFieldMap.WithVariables | DynamicField.WithVariables | undefined,
     /** The depth of the node (allows us to set the path correctly). */
     public readonly depth: number,
     /** The key/index of this node, relative to its parent. */
@@ -42,7 +42,7 @@ export type PayloadVisitor = (
   path: PathPart[],
   payloadValue: JsonValue,
   nodeValue: JsonValue | undefined,
-  dynamicField: DynamicField | DynamicFieldMap | undefined,
+  dynamicField: DynamicField.WithVariables | DynamicFieldMap.WithVariables | undefined,
 ) => boolean;
 
 /**
@@ -61,7 +61,7 @@ export type PayloadVisitor = (
 export function walkPayload(
   payload: JsonValue,
   node: JsonValue | undefined,
-  rootFieldMap: DynamicField | DynamicFieldMap | undefined,
+  rootFieldMap: DynamicField.WithVariables | DynamicFieldMap.WithVariables | undefined,
   visitRoot: boolean,
   visitor: PayloadVisitor,
 ) {

--- a/src/util/tree.ts
+++ b/src/util/tree.ts
@@ -26,7 +26,7 @@ class PayloadWalkNode {
     /** The value of the current node at this location in the walk. */
     public readonly node: JsonValue | undefined,
     /** The value of the field map at this location in the walk. */
-    public readonly fieldMap: DynamicFieldMap.WithoutVariables | DynamicField.WithoutVariables | undefined,
+    public readonly fieldMap: DynamicFieldMap | DynamicField | undefined,
     /** The depth of the node (allows us to set the path correctly). */
     public readonly depth: number,
     /** The key/index of this node, relative to its parent. */
@@ -42,7 +42,7 @@ export type PayloadVisitor = (
   path: PathPart[],
   payloadValue: JsonValue,
   nodeValue: JsonValue | undefined,
-  dynamicField: DynamicField.WithoutVariables | DynamicFieldMap.WithoutVariables | undefined,
+  dynamicField: DynamicField | DynamicFieldMap | undefined,
 ) => boolean;
 
 /**
@@ -61,7 +61,7 @@ export type PayloadVisitor = (
 export function walkPayload(
   payload: JsonValue,
   node: JsonValue | undefined,
-  rootFieldMap: DynamicField.WithoutVariables | DynamicFieldMap.WithoutVariables | undefined,
+  rootFieldMap: DynamicField | DynamicFieldMap | undefined,
   visitRoot: boolean,
   visitor: PayloadVisitor,
 ) {

--- a/src/util/tree.ts
+++ b/src/util/tree.ts
@@ -26,7 +26,7 @@ class PayloadWalkNode {
     /** The value of the current node at this location in the walk. */
     public readonly node: JsonValue | undefined,
     /** The value of the field map at this location in the walk. */
-    public readonly fieldMap: DynamicFieldMap.WithVariables | DynamicField.WithVariables | undefined,
+    public readonly fieldMap: DynamicFieldMap.WithoutVariables | DynamicField.WithoutVariables | undefined,
     /** The depth of the node (allows us to set the path correctly). */
     public readonly depth: number,
     /** The key/index of this node, relative to its parent. */
@@ -42,7 +42,7 @@ export type PayloadVisitor = (
   path: PathPart[],
   payloadValue: JsonValue,
   nodeValue: JsonValue | undefined,
-  dynamicField: DynamicField.WithVariables | DynamicFieldMap.WithVariables | undefined,
+  dynamicField: DynamicField.WithoutVariables | DynamicFieldMap.WithoutVariables | undefined,
 ) => boolean;
 
 /**
@@ -61,7 +61,7 @@ export type PayloadVisitor = (
 export function walkPayload(
   payload: JsonValue,
   node: JsonValue | undefined,
-  rootFieldMap: DynamicField.WithVariables | DynamicFieldMap.WithVariables | undefined,
+  rootFieldMap: DynamicField.WithoutVariables | DynamicFieldMap.WithoutVariables | undefined,
   visitRoot: boolean,
   visitor: PayloadVisitor,
 ) {

--- a/test/unit/DynamicField/expandVariables.ts
+++ b/test/unit/DynamicField/expandVariables.ts
@@ -1,0 +1,106 @@
+import gql from 'graphql-tag';
+
+import { QueryInfo } from '../../../src/context';
+import { DynamicField, expandVariables } from '../../../src/DynamicField';
+
+describe(`DynamicField.expandVariables`, () => {
+
+  function makeFieldMap(query: string) {
+    return new QueryInfo(gql(query)).dynamicFieldMap;
+  }
+
+  it(`passes undefined through`, () => {
+    expect(expandVariables(undefined, undefined)).to.eq(undefined);
+  });
+
+  it(`handles static queries`, () => {
+    const map = makeFieldMap(`
+      query stuff {
+        foo(limit: 5) {
+          bar(tag: "hello")
+        }
+        baz(thing: null)
+      }
+    `);
+
+    expect(expandVariables(map, undefined)).to.deep.eq({
+      foo: new DynamicField({ limit: 5 }, undefined, {
+        bar: new DynamicField({ tag: 'hello' }),
+      }),
+      baz: new DynamicField({ thing: null }),
+    });
+  });
+
+  it(`replaces top level variables`, () => {
+    const map = makeFieldMap(`
+      query stuff($foo: ID!, $bar: String) {
+        thing(a: $foo, b: $bar)
+      }
+    `);
+
+    expect(expandVariables(map, { foo: 123, bar: 'ohai' })).to.deep.eq({
+      thing: new DynamicField({ a: 123, b: 'ohai' }),
+    });
+  });
+
+  it(`replaces top level variables of nested fields`, () => {
+    const map = makeFieldMap(`
+      query stuff($foo: ID!, $bar: String) {
+        one {
+          two(a: $foo) {
+            three {
+              four(b: $bar)
+            }
+          }
+        }
+      }
+    `);
+
+    expect(expandVariables(map, { foo: 123, bar: 'ohai' })).to.deep.eq({
+      one: {
+        two: new DynamicField({ a: 123 }, undefined, {
+          three: {
+            four: new DynamicField({ b: 'ohai' }),
+          },
+        }),
+      },
+    });
+  });
+
+  it(`replaces nested variables`, () => {
+    const map = makeFieldMap(`
+      query stuff($foo: ID!, $bar: String) {
+        thing(one: { two: $bar, three: [1, 2, $foo] })
+      }
+    `);
+
+    expect(expandVariables(map, { foo: 123, bar: 'ohai' })).to.deep.eq({
+      thing: new DynamicField({ one: { two: 'ohai', three: [1, 2, 123] } }),
+    });
+  });
+
+  it(`asserts that variables are provided when passed undefined`, () => {
+    const map = makeFieldMap(`
+      query stuff($foo: ID!, $bar: String) {
+        thing(a: $foo, b: $bar)
+      }
+    `);
+
+    expect(() => {
+      expandVariables(map, undefined);
+    }).to.throw(/\$(foo|bar)/);
+  });
+
+  it(`asserts that variables are provided`, () => {
+    const map = makeFieldMap(`
+      query stuff($foo: ID!, $bar: String) {
+        thing(a: $foo, b: $bar)
+      }
+    `);
+
+    expect(() => {
+      expandVariables(map, { foo: 123 });
+    }).to.throw(/\$bar/);
+  });
+
+});


### PR DESCRIPTION
Fixes #85 

We now have two "kinds" of `DynamicField`s - those with `VariableArgument`s in their arguments, and those without.  The result of parsing the AST yields (potentially) fields with variables.  

However, when parsing a query (`CacheContext#parseQuery`), we immediately substitute in the values for those variables, to minimize work when reading/writing.  This also allows us to trivially support optional & default field arguments