### PR TITLE
Use a cache of code between workflow steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ base_image: &base_image
 job_common: &job_common
   docker:
     - <<: *base_image
-  working_directory: ~/sandbox/code
 
 restore: &restore
   restore_cache:
@@ -14,19 +13,18 @@ restore: &restore
 
 store_artifacts: &store_artifacts
   store_artifacts:
-    path: ~/sandbox/code/output
+    path: output
     destination: /
 
 store_test_results: &store_test_results
   store_test_results:
-    path: ~/sandbox/code/output
+    path: output
 
 jobs:
   build:
     <<: *job_common
     steps:
-      - checkout:
-          path: ~/sandbox/code
+      - checkout
       - restore_cache:
           key: dependencies-{{ checksum "yarn.lock" }}
       - run: yarn run greenkeeper:lockfile
@@ -34,12 +32,12 @@ jobs:
       - save_cache:
           key: dependencies-{{ checksum "yarn.lock" }}
           paths:
-            - ~/sandbox/code/node_modules
+            - node_modules
       - run: yarn run compile
       - save_cache:
           key: code-{{ .Revision }}
           paths:
-            - code
+            - .
 
   test:style:
     <<: *job_common

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,9 @@ job_common: &job_common
     - <<: *base_image
   working_directory: ~/sandbox/code
 
-attach: &attach
-  attach_workspace:
-    at: ~/sandbox
+restore: &restore
+  restore_cache:
+    key: code-{{ .Revision }}
 
 store_artifacts: &store_artifacts
   store_artifacts:
@@ -36,23 +36,22 @@ jobs:
           paths:
             - ~/sandbox/code/node_modules
       - run: yarn run compile
-      - persist_to_workspace:
-          root: ~/sandbox
-          paths: code
+      - save_cache:
+          key: code-{{ .Revision }}
+          paths:
+            - code
 
   test:style:
     <<: *job_common
     steps:
-      - checkout
-      - <<: *attach
+      - <<: *restore
       - run: yarn run test:style
       - <<: *store_artifacts
 
   test:unit:
     <<: *job_common
     steps:
-      - checkout
-      - <<: *attach
+      - <<: *restore
       - run: ls -R src test
       - run: yarn run test:unit:coverage
       - <<: *store_artifacts
@@ -61,8 +60,7 @@ jobs:
   release:
     <<: *job_common
     steps:
-      - checkout
-      - <<: *attach
+      - <<: *restore
       - run: yarn config set registry https://registry.npmjs.org/
       - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - run: git config --global user.email "donvoy@convoy.com"


### PR DESCRIPTION
Drop the workspace and use caches instead:

* Can now rebuild individual steps
* Each step does minimal work