### PR TITLE
Track all queries we've previously written, and ensure that they come back as complete

### DIFF
--- a/src/context/CacheContext.ts
+++ b/src/context/CacheContext.ts
@@ -58,7 +58,7 @@ export class CacheContext {
   /** Retrieve the EntityId for a given node, if any. */
   readonly entityIdForNode: CacheContext.EntityIdForNode;
 
-  /** Run transformation on changed entity node, if any */
+  /** Run transformation on changed entity node, if any. */
   readonly entityTransformer: CacheContext.EntityTransformer | undefined;
 
   /** Whether __typename should be injected into nodes in queries. */

--- a/src/context/CacheContext.ts
+++ b/src/context/CacheContext.ts
@@ -4,7 +4,7 @@ import lodashIsEqual = require('lodash.isequal');
 import { expandVariables } from '../DynamicField';
 import { JsonObject } from '../primitive';
 import { EntityId, ParsedQuery, Query } from '../schema';
-import { addTypenameToDocument, isObject } from '../util';
+import { addToSet, addTypenameToDocument, isObject } from '../util';
 
 import { QueryInfo } from './QueryInfo';
 
@@ -67,6 +67,8 @@ export class CacheContext {
   private readonly _queryInfoMap = new Map<string, QueryInfo>();
   /** All currently known & parsed queries, for identity mapping. */
   private readonly _parsedQueriesMap = new Map<string, ParsedQuery[]>();
+  /** All queries that have been successfully written to the cache. */
+  private readonly _writtenQueries = new Set<ParsedQuery>();
   /** The logger we should use. */
   private readonly _logger: CacheContext.Logger;
 
@@ -129,6 +131,24 @@ export class CacheContext {
    */
   error(message: string, ...metadata: any[]): void {
     this._logger.error(message, ...metadata);
+  }
+
+  /**
+   * Mark a query as having been successfully written into the graph.
+   */
+  markQueriesWritten(parsed: Iterable<ParsedQuery>): void {
+    addToSet(this._writtenQueries, parsed);
+  }
+
+  /**
+   * Whether we've previously written a query to the cache (and that reads
+   * against it should be considered complete).
+   *
+   * Once written, it's impossible for a read of that same query to be
+   * considered incomplete (we never remove reachable nodes in the graph).
+   */
+  wasQueryWritten(parsed: ParsedQuery): boolean {
+    return this._writtenQueries.has(parsed);
   }
 
   /**

--- a/src/context/QueryInfo.ts
+++ b/src/context/QueryInfo.ts
@@ -30,6 +30,8 @@ export class QueryInfo {
   public readonly operationType: OperationTypeNode;
   /** The name of the operation. */
   public readonly operationName?: string;
+  /** The GQL source of the operation */
+  public readonly operationSource?: string;
   /** All fragments in the document, indexed by name. */
   public readonly fragmentMap: FragmentMap;
   /**
@@ -51,6 +53,7 @@ export class QueryInfo {
     this.operation = getOperationOrDie(document);
     this.operationType = this.operation.operation;
     this.operationName = this.operation.name && this.operation.name.value;
+    this.operationSource = this.operation.loc && this.operation.loc.source.body;
     this.fragmentMap = fragmentMapForDocument(document);
 
     const { fieldMap, variables } = compileDynamicFields(this.fragmentMap, this.operation.selectionSet);

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -21,6 +21,7 @@ import {
 export interface EditedSnapshot {
   snapshot: GraphSnapshot;
   editedNodeIds: Set<NodeId>;
+  writtenQueries: Set<ParsedQuery>;
 }
 
 /**
@@ -74,6 +75,9 @@ export class SnapshotEditor {
    */
   private _rebuiltNodeIds = new Set<NodeId>();
 
+  /** The queries that were written, and should now be considered complete. */
+  private _writtenQueries = new Set<ParsedQuery>();
+
   constructor(
     /** The configuration/context to use when editing snapshots. */
     private _context: CacheContext,
@@ -109,6 +113,9 @@ export class SnapshotEditor {
 
     // Remove (garbage collect) orphaned subgraphs.
     this._removeOrphanedNodes(orphanedNodeIds);
+
+    // The query should now be considered complete for future reads.
+    this._writtenQueries.add(parsed);
   }
 
   /**
@@ -386,6 +393,7 @@ export class SnapshotEditor {
     return {
       snapshot: new GraphSnapshot(snapshots),
       editedNodeIds: this._editedNodeIds,
+      writtenQueries: this._writtenQueries,
     };
   }
 


### PR DESCRIPTION
We've been seeing a few cases where we've written a payload to the cache, but then had it marked incomplete when immediately read.

This should help to track those cases down (and also recover from them)