### PR TITLE
Garbage collect parameterized edges in nodes that are removed from arrays

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
       "protocol": "legacy",
       "console": "integratedTerminal",
       "name": "test:unit",
-      "runtimeExecutable": "${workspaceRoot}/scripts/test:unit.sh",
+      "runtimeExecutable": "${workspaceRoot}/scripts/test-unit.sh",
       "runtimeArgs": [
         "--runInBand"
       ]

--- a/src/nodes/NodeSnapshot.ts
+++ b/src/nodes/NodeSnapshot.ts
@@ -27,9 +27,6 @@ export interface NodeReference {
 
   /**
    * The path (object/array keys) within the node to the reference.
-   *
-   * If the path is omitted, this reference is used purely for garbage
-   * collection, but is not walked when regenerating node references.
    */
-  path?: PathPart[];
+  path: PathPart[];
 }

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -255,7 +255,6 @@ export class SnapshotEditor {
 
           // Also remove any references contained within any entries we removed:
           //
-          // TODO: Deal with parameterized fields contained by this.
           // TODO: Better abstract this.  It has a lot of similarity with
           // _mergeReferenceEdits.
           if (payloadLength < nodeLength && containerSnapshot && containerSnapshot.outbound) {
@@ -343,7 +342,7 @@ export class SnapshotEditor {
     while (queue.length) {
       const nodeId = queue.pop()!;
       const snapshot = this.getNodeSnapshot(nodeId);
-      if (snapshot instanceof ParameterizedValueSnapshot) continue;
+      if (!(snapshot instanceof EntitySnapshot)) continue;
       if (!snapshot || !snapshot.inbound) continue;
 
       for (const { id, path } of snapshot.inbound) {

--- a/src/util/references.ts
+++ b/src/util/references.ts
@@ -15,7 +15,7 @@ export function removeNodeReference(
   direction: ReferenceDirection,
   snapshot: NodeSnapshot,
   id: NodeId,
-  path?: PathPart[],
+  path: PathPart[],
 ): boolean {
   const references = snapshot[direction];
   if (!references) return true;
@@ -37,7 +37,7 @@ export function addNodeReference(
   direction: ReferenceDirection,
   snapshot: NodeSnapshot,
   id: NodeId,
-  path?: PathPart[],
+  path: PathPart[],
 ): boolean {
   let references = snapshot[direction];
   if (!references) {
@@ -60,7 +60,7 @@ export function hasNodeReference(
   snapshot: NodeSnapshot,
   type: ReferenceDirection,
   id: NodeId,
-  path?: PathPart[],
+  path: PathPart[],
 ): boolean {
   const references = snapshot[type];
   if (!references || getIndexOfGivenReference(references, id, path) === -1) return false;
@@ -71,7 +71,7 @@ export function hasNodeReference(
  * Return index of { id, path } reference in references array.
  * Otherwise, return -1.
  */
-function getIndexOfGivenReference(references: NodeReference[], id: NodeId, path?: PathPart[]): number {
+function getIndexOfGivenReference(references: NodeReference[], id: NodeId, path: PathPart[]): number {
   return references.findIndex((reference) => {
     return reference.id === id && lodashIsEqual(reference.path, path);
   });

--- a/test/unit/operations/write/parameterizedFields.ts
+++ b/test/unit/operations/write/parameterizedFields.ts
@@ -55,12 +55,12 @@ describe(`operations.write`, () => {
 
       it(`creates an outgoing reference from the field's container`, () => {
         const queryRoot = snapshot.getNodeSnapshot(QueryRootId)!;
-        expect(queryRoot.outbound).to.deep.eq([{ id: parameterizedId, path: undefined }]);
+        expect(queryRoot.outbound).to.deep.eq([{ id: parameterizedId, path: ['foo'] }]);
       });
 
       it(`creates an inbound reference to the field's container`, () => {
         const values = snapshot.getNodeSnapshot(parameterizedId)!;
-        expect(values.inbound).to.deep.eq([{ id: QueryRootId, path: undefined }]);
+        expect(values.inbound).to.deep.eq([{ id: QueryRootId, path: ['foo'] }]);
       });
 
       it(`does not expose the parameterized field directly from its container`, () => {
@@ -113,12 +113,12 @@ describe(`operations.write`, () => {
 
       it(`creates an outgoing reference from the field's container`, () => {
         const queryRoot = snapshot.getNodeSnapshot(QueryRootId)!;
-        expect(queryRoot.outbound).to.deep.eq([{ id: parameterizedId, path: undefined }]);
+        expect(queryRoot.outbound).to.deep.eq([{ id: parameterizedId, path: ['foo', 'bar', 'baz'] }]);
       });
 
       it(`creates an inbound reference to the field's container`, () => {
         const values = snapshot.getNodeSnapshot(parameterizedId)!;
-        expect(values.inbound).to.deep.eq([{ id: QueryRootId, path: undefined }]);
+        expect(values.inbound).to.deep.eq([{ id: QueryRootId, path: ['foo', 'bar', 'baz'] }]);
       });
 
       it(`does not expose the parameterized field directly from its container`, () => {
@@ -217,12 +217,12 @@ describe(`operations.write`, () => {
 
       it(`creates an outgoing reference from the field's container`, () => {
         const queryRoot = snapshot.getNodeSnapshot(QueryRootId)!;
-        expect(queryRoot.outbound).to.deep.eq([{ id: parameterizedId, path: undefined }]);
+        expect(queryRoot.outbound).to.deep.eq([{ id: parameterizedId, path: ['foo'] }]);
       });
 
       it(`creates an inbound reference to the field's container`, () => {
         const values = snapshot.getNodeSnapshot(parameterizedId)!;
-        expect(values.inbound).to.deep.eq([{ id: QueryRootId, path: undefined }]);
+        expect(values.inbound).to.deep.eq([{ id: QueryRootId, path: ['foo'] }]);
       });
 
       it(`creates an outgoing reference from the parameterized field to the referenced entity`, () => {
@@ -448,16 +448,16 @@ describe(`operations.write`, () => {
         const entry1 = snapshot.getNodeSnapshot(entry1Id)!;
         const entry2 = snapshot.getNodeSnapshot(entry2Id)!;
 
-        expect(entry1.inbound).to.have.deep.members([{ id: containerId, path: undefined }]);
-        expect(entry2.inbound).to.have.deep.members([{ id: containerId, path: undefined }]);
+        expect(entry1.inbound).to.have.deep.members([{ id: containerId, path: [0, 'three', 'four'] }]);
+        expect(entry2.inbound).to.have.deep.members([{ id: containerId, path: [1, 'three', 'four'] }]);
       });
 
       it(`references the children from the parent`, () => {
         const container = snapshot.getNodeSnapshot(containerId)!;
 
         expect(container.outbound).to.have.deep.members([
-          { id: entry1Id, path: undefined },
-          { id: entry2Id, path: undefined },
+          { id: entry1Id, path: [0, 'three', 'four'] },
+          { id: entry2Id, path: [1, 'three', 'four'] },
         ]);
       });
 
@@ -508,12 +508,12 @@ describe(`operations.write`, () => {
 
       it(`creates an outgoing reference from the field's container`, () => {
         const queryRoot = snapshot.getNodeSnapshot(QueryRootId)!;
-        expect(queryRoot.outbound).to.deep.eq([{ id: parameterizedId, path: undefined }]);
+        expect(queryRoot.outbound).to.deep.eq([{ id: parameterizedId, path: ['foo'] }]);
       });
 
       it(`creates an inbound reference to the field's container`, () => {
         const values = snapshot.getNodeSnapshot(parameterizedId)!;
-        expect(values.inbound).to.deep.eq([{ id: QueryRootId, path: undefined }]);
+        expect(values.inbound).to.deep.eq([{ id: QueryRootId, path: ['foo'] }]);
       });
 
       it(`does not expose the parameterized field directly from its container`, () => {
@@ -551,12 +551,12 @@ describe(`operations.write`, () => {
 
       it(`creates an outgoing reference from the field's container`, () => {
         const queryRoot = snapshot.getNodeSnapshot(QueryRootId)!;
-        expect(queryRoot.outbound).to.deep.eq([{ id: parameterizedId, path: undefined }]);
+        expect(queryRoot.outbound).to.deep.eq([{ id: parameterizedId, path: ['foo'] }]);
       });
 
       it(`creates an inbound reference to the field's container`, () => {
         const values = snapshot.getNodeSnapshot(parameterizedId)!;
-        expect(values.inbound).to.deep.eq([{ id: QueryRootId, path: undefined }]);
+        expect(values.inbound).to.deep.eq([{ id: QueryRootId, path: ['foo'] }]);
       });
 
       it(`does not expose the parameterized field directly from its container`, () => {


### PR DESCRIPTION
* Makes `path` a required property on all references
* We now inspect the kind of node being traversed when rebuilding references (only rebuild entity references!)
* Fixes garbage collection of parameterized edges contained within arrays