### PR TITLE
update typescript and fix error

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "jest": "^20.0.4",
     "jest-junit": "^3.0.0",
     "rimraf": "^2.6.1",
-    "typescript": "^2.4.2",
+    "typescript": "^2.5.2",
     "typescript-eslint-parser": "^7.0.0"
   },
   "dependencies": {

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -2,7 +2,7 @@ import { CacheContext } from '../context';
 import { DynamicField, DynamicFieldWithArgs, DynamicFieldMap, isDynamicFieldWithArgs } from '../DynamicField';
 import { GraphSnapshot } from '../GraphSnapshot';
 import { EntitySnapshot, NodeSnapshot, ParameterizedValueSnapshot, cloneNodeSnapshot } from '../nodes';
-import { JsonObject, PathPart } from '../primitive';
+import { JsonObject, PathPart, JsonScalar, NestedObject } from '../primitive';
 import { NodeId, ParsedQuery, Query } from '../schema';
 import {
   addNodeReference,
@@ -278,7 +278,11 @@ export class SnapshotEditor {
         // TODO: Rather than detecting empty objects directly (which should
         // never occur for GraphQL results, and only for custom types), we
         // should be walking the selection set of the query.
-        } else if (payloadIsObject && !Object.keys(payloadValue).length && (!nodeIsObject || Object.keys(payloadValue).length)) {
+        } else if (
+          payloadIsObject &&
+          !Object.keys((payloadValue as NestedObject<JsonScalar>)).length &&
+          (!nodeIsObject || Object.keys((payloadValue as NestedObject<JsonScalar>)).length)
+        ) {
           this._setValue(containerId, path, payloadValue);
         }
 


### PR DESCRIPTION
<!--
Thanks for helping out!  To make sure your pull request goes smoothly, here's a quick checklist to walk through:

✔ Write a summary

Please summarize your change, and provide as much context as you can.  What's your motivation for the change?  Why'd you take this approach?  Links to related issues?  Etc.  Helps the reviewer give more thoughtful feedback.

✔ Tests!

This repository requires a decent amount of coverage on all changes, in an effort to keep master green.  So, please write tests for any new feature you write - and, if possible, regression tests for bugs you've fixed.

✔ Bump the version if needed

This repository automatically publishes every commit on master to npm, and increments the Z version for you.  So:

* Fixing a bug?  Thanks!
  You don't need to touch the version.

* Adding a new, backwards-compatible, feature?  Sweet!
  Please increment the Y version in package.json.

* Making a breaking change to an existing API?  Welp, that's how it goes.
  Please increment the X version in package.json.

-->
Since TypeScript 2.5 came out, the `^2.4.2` installs it by default. With that version, there was a TypeError for calling `Object.keys` on a possible non object. This force casts the type def for it.