### PR TITLE
Refactor SnapshotEditor a bit

### DIFF
--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -314,8 +314,20 @@ export class SnapshotEditor {
    * Commits the transaction, returning a new immutable snapshot.
    */
   commit(): EditedSnapshot {
+    return {
+      snapshot: this._buildNewSnapshot(),
+      editedNodeIds: this._editedNodeIds,
+      writtenQueries: this._writtenQueries,
+    };
+  }
+
+  /**
+   * Collect all our pending changes into a new GraphSnapshot.
+   */
+  _buildNewSnapshot() {
     const { entityTransformer } = this._context;
     const snapshots = { ...this._parent._values };
+
     for (const id in this._newNodes) {
       const newSnapshot = this._newNodes[id];
       // Drop snapshots that were garbage collected.
@@ -330,11 +342,7 @@ export class SnapshotEditor {
       }
     }
 
-    return {
-      snapshot: new GraphSnapshot(snapshots),
-      editedNodeIds: this._editedNodeIds,
-      writtenQueries: this._writtenQueries,
-    };
+    return new GraphSnapshot(snapshots);
   }
 
   /**

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -108,12 +108,6 @@ export class SnapshotEditor {
     // nodes, and collects all newly orphaned nodes.
     const orphanedNodeIds = this._mergeReferenceEdits(referenceEdits);
 
-    // At this point, every node that has had any of its properties change now
-    // exists in _newNodes.  In order to preserve immutability, we need to walk
-    // all nodes that transitively reference an edited node, and update their
-    // references to point to the new version.
-    this._rebuildInboundReferences();
-
     // Remove (garbage collect) orphaned subgraphs.
     this._removeOrphanedNodes(orphanedNodeIds);
 
@@ -314,6 +308,12 @@ export class SnapshotEditor {
    * Commits the transaction, returning a new immutable snapshot.
    */
   commit(): EditedSnapshot {
+    // At this point, every node that has had any of its properties change now
+    // exists in _newNodes.  In order to preserve immutability, we need to walk
+    // all nodes that transitively reference an edited node, and update their
+    // references to point to the new version.
+    this._rebuildInboundReferences();
+
     return {
       snapshot: this._buildNewSnapshot(),
       editedNodeIds: this._editedNodeIds,
@@ -334,7 +334,7 @@ export class SnapshotEditor {
       if (newSnapshot === undefined) {
         delete snapshots[id];
       } else {
-        // TODO: This should not be run for PArameterizedValueSnapshots
+        // TODO: This should not be run for ParameterizedValueSnapshots
         if (entityTransformer) {
           const { node } = this._newNodes[id] as EntitySnapshot;
           if (node) entityTransformer(node);

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -334,6 +334,7 @@ export class SnapshotEditor {
       if (newSnapshot === undefined) {
         delete snapshots[id];
       } else {
+        // TODO: This should not be run for PArameterizedValueSnapshots
         if (entityTransformer) {
           const { node } = this._newNodes[id] as EntitySnapshot;
           if (node) entityTransformer(node);


### PR DESCRIPTION
This is a slight perf optimization for optimistic updates - we move the inbound reference rewriting to commit(), so that it only occurs once when we merge multiple payloads in the same transaction.