### PR TITLE
Let orphaned array references leak for now

### DIFF
--- a/test/unit/operations/write/editValues.ts
+++ b/test/unit/operations/write/editValues.ts
@@ -229,7 +229,7 @@ describe(`operations.write`, () => {
 
   });
 
-  describe(`edt references in an array`, () => {
+  describe(`edit references in an array`, () => {
     let arrayQuery: Query, snapshot: GraphSnapshot;
     beforeAll(() => {
       arrayQuery = query(`{

--- a/test/unit/operations/write/editValues.ts
+++ b/test/unit/operations/write/editValues.ts
@@ -277,7 +277,7 @@ describe(`operations.write`, () => {
       ]);
     });
 
-    it(`drops references when the array shrinks`, () => {
+    it.skip(`drops references when the array shrinks`, () => {
       const updated = write(context, snapshot, arrayQuery, {
         things: [
           { id: 1, name: 'One' },

--- a/test/unit/operations/write/orphans.ts
+++ b/test/unit/operations/write/orphans.ts
@@ -64,7 +64,7 @@ describe(`operations.write`, () => {
 
   });
 
-  describe(`orphane a node`, () => {
+  describe(`orphan a node`, () => {
 
     let baseline: GraphSnapshot, snapshot: GraphSnapshot, editedNodeIds: Set<NodeId>;
     beforeAll(() => {
@@ -112,7 +112,7 @@ describe(`operations.write`, () => {
     });
   });
 
-  describe(`orphane a subgraph`, () => {
+  describe(`orphan a subgraph`, () => {
 
     let baseline: GraphSnapshot, snapshot: GraphSnapshot, editedNodeIds: Set<NodeId>;
     beforeAll(() => {

--- a/test/unit/operations/write/parameterizedFields.ts
+++ b/test/unit/operations/write/parameterizedFields.ts
@@ -537,7 +537,7 @@ describe(`operations.write`, () => {
         ]);
       });
 
-      it(`allows shifting from the front`, () => {
+      it.skip(`allows shifting from the front`, () => {
         const updated = write(context, snapshot, nestedQuery, {
           one: {
             two: [
@@ -643,7 +643,7 @@ describe(`operations.write`, () => {
 
     });
 
-    describe(`removing array nodes that contain parameterized values`, () => {
+    describe.skip(`removing array nodes that contain parameterized values`, () => {
 
       let rootedQuery: Query, snapshot: GraphSnapshot, value1Id: NodeId, value2Id: NodeId;
       beforeAll(() => {

--- a/test/unit/operations/write/parameterizedFields.ts
+++ b/test/unit/operations/write/parameterizedFields.ts
@@ -487,6 +487,76 @@ describe(`operations.write`, () => {
 
     });
 
+    describe(`with nested entities in an array`, () => {
+
+      let nestedQuery: Query, snapshot: GraphSnapshot, containerId: NodeId;
+      beforeAll(() => {
+        nestedQuery = query(`query nested($id: ID!) {
+          one {
+            two(id: $id) {
+              three { id }
+            }
+          }
+        }`, { id: 1 });
+
+        containerId = nodeIdForParameterizedValue(QueryRootId, ['one', 'two'], { id: 1 });
+
+        snapshot = write(context, empty, nestedQuery, {
+          one: {
+            two: [
+              { three: { id: 1 } },
+              { three: { id: 2 } },
+            ],
+          },
+        }).snapshot;
+      });
+
+      it(`writes a value snapshot for the containing field`, () => {
+        expect(snapshot.getNodeSnapshot(containerId)).to.exist;
+      });
+
+      it(`writes value snapshots for each array entry`, () => {
+        expect(snapshot.getNodeSnapshot('1')).to.exist;
+        expect(snapshot.getNodeSnapshot('2')).to.exist;
+      });
+
+      it(`references the parent snapshot from the children`, () => {
+        const entry1 = snapshot.getNodeSnapshot('1')!;
+        const entry2 = snapshot.getNodeSnapshot('2')!;
+
+        expect(entry1.inbound).to.have.deep.members([{ id: containerId, path: [0, 'three'] }]);
+        expect(entry2.inbound).to.have.deep.members([{ id: containerId, path: [1, 'three'] }]);
+      });
+
+      it(`references the children from the parent`, () => {
+        const container = snapshot.getNodeSnapshot(containerId)!;
+
+        expect(container.outbound).to.have.deep.members([
+          { id: '1', path: [0, 'three'] },
+          { id: '2', path: [1, 'three'] },
+        ]);
+      });
+
+      it(`allows shifting from the front`, () => {
+        const updated = write(context, snapshot, nestedQuery, {
+          one: {
+            two: [
+              { three: { id: 2 } },
+            ],
+          },
+        }).snapshot;
+
+        expect(updated.getNodeSnapshot(containerId)!.outbound).to.have.deep.members([
+          { id: '2', path: [0, 'three'] },
+        ]);
+
+        expect(updated.getNodeSnapshot('2')!.inbound).to.have.deep.members([
+          { id: containerId, path: [0, 'three'] },
+        ]);
+      });
+
+    });
+
     describe(`optional arguments`, () => {
 
       let snapshot: GraphSnapshot, editedNodeIds: Set<NodeId>, parameterizedId: NodeId;


### PR DESCRIPTION
Our previous logic was removing the wrong references from arrays that also change their order (such as shifting the first value off of an array).

This removes our logic for GCing orphaned array references - prefer leaking over wonky behavior