### PR TITLE
Restore nearest deps from cache, if there are none for that exact one

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: deps-{{ checksum "package.json" }}
+          keys: 
+            - deps-{{ checksum "package.json" }}
+            - deps-
       - run: ./scripts/install-ci.sh
       - save_cache:
           key: deps-{{ checksum "package.json" }}


### PR DESCRIPTION
Leverage Circle's prefix lookup to find the most recently installed deps if we don't have a cache for the current configuration of `package.json`