### PR TITLE
Drop write tracking

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -117,9 +117,8 @@ export class Cache implements Queryable {
       return false;
     }
 
-    const { snapshot, editedNodeIds, writtenQueries } = transaction.commit();
+    const { snapshot, editedNodeIds } = transaction.commit();
     this._setSnapshot(snapshot, editedNodeIds);
-    this._context.markOperationsWritten(writtenQueries);
 
     return true;
   }

--- a/src/context/CacheContext.ts
+++ b/src/context/CacheContext.ts
@@ -5,7 +5,7 @@ import lodashGet = require('lodash.get');
 import { areChildrenDynamic, expandVariables } from '../ParsedQueryNode';
 import { JsonObject } from '../primitive';
 import { EntityId, OperationInstance, RawOperation } from '../schema';
-import { addToSet, isObject } from '../util';
+import { isObject } from '../util';
 
 import { QueryInfo } from './QueryInfo';
 
@@ -93,8 +93,6 @@ export class CacheContext {
   private readonly _queryInfoMap = new Map<string, QueryInfo>();
   /** All currently known & parsed queries, for identity mapping. */
   private readonly _operationMap = new Map<string, OperationInstance[]>();
-  /** All queries that have been successfully written to the cache. */
-  private readonly _writtenQueries = new Set<OperationInstance>();
   /** The logger we should use. */
   private readonly _logger: CacheContext.Logger;
 
@@ -198,24 +196,6 @@ export class CacheContext {
     } finally {
       this._logger.groupEnd();
     }
-  }
-
-  /**
-   * Mark a query as having been successfully written into the graph.
-   */
-  markOperationsWritten(parsed: Iterable<OperationInstance>): void {
-    addToSet(this._writtenQueries, parsed);
-  }
-
-  /**
-   * Whether we've previously written a query to the cache (and that reads
-   * against it should be considered complete).
-   *
-   * Once written, it's impossible for a read of that same query to be
-   * considered incomplete (we never remove reachable nodes in the graph).
-   */
-  wasOperationWritten(parsed: OperationInstance): boolean {
-    return this._writtenQueries.has(parsed);
   }
 
   /**

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -37,19 +37,6 @@ export function read(context: CacheContext, query: RawOperation, snapshot: Graph
 
     let { complete, nodeIds } = _visitSelection(operation, context, result, includeNodeIds);
 
-    // This should NEVER be true.
-    //
-    // TODO: Once we've nailed down all the bugs; consider skipping
-    // _visitSelection for known complete queries (and drop nodeIds tracking?)
-    if (!complete && context.wasOperationWritten(operation)) {
-      context.error(`BUG: the most recently written query was marked incomplete`, {
-        queryName: operation.info.operationName,
-        query: operation.info.operationSource,
-      });
-      // Attempt to recover; though this likely means the cache is corrupt.
-      complete = true;
-    }
-
     queryResult = { result, complete, nodeIds };
     snapshot.readCache.set(operation, queryResult as QueryResult);
 


### PR DESCRIPTION
It turns out it's legitimate for a previously written query to transition from complete to incomplete.  For example:

```json
{"foo": null}
```

satisfies `{ foo { bar } }`

```json
{"foo": {"fizz": 123} }`
```

no longer satisfies `{ foo { bar } }`