### PR TITLE
Ensure variables used in directives are collected

### DIFF
--- a/src/context/CacheContext.ts
+++ b/src/context/CacheContext.ts
@@ -146,7 +146,6 @@ export class CacheContext {
    * any other method in the cache.
    */
   transformDocument(document: DocumentNode): DocumentNode {
-    // TODO: memoize?
     return this._addTypename ? addTypenameToDocument(document) : document;
   }
 

--- a/test/unit/ParsedQueryNode/directives.ts
+++ b/test/unit/ParsedQueryNode/directives.ts
@@ -1,0 +1,53 @@
+import gql from 'graphql-tag';
+
+import { CacheContext } from '../../../src/context';
+import { parseQuery } from '../../../src/ParsedQueryNode';
+import { fragmentMapForDocument, getOperationOrDie } from '../../../src/util';
+import { strictConfig } from '../../helpers';
+
+describe(`parseQuery with queries with directives`, () => {
+
+  const context = new CacheContext(strictConfig);
+  function parseOperation(operationString: string) {
+    const document = gql(operationString);
+    const operation = getOperationOrDie(document);
+    const FragmentMap = fragmentMapForDocument(document);
+    return parseQuery(context, FragmentMap, operation.selectionSet);
+  }
+
+  it(`collects variables in directives on fields`, () => {
+    const operation = `{
+      foo {
+        bar @simple(arg: $varA)
+        baz(bat: "bad") @complex(arg0: $varB, arg1: $varC)
+      }
+    }`;
+    expect(parseOperation(operation).variables).to.deep.eq(
+      new Set(['varA', 'varB', 'varC'])
+    );
+  });
+
+  it(`collects variables in directives in and on fragments`, () => {
+    const operation = `
+      query getThings {
+        foo {
+          ...smallFoo @simple(arg0: $varD)
+          ...bigFoo
+        }
+      }
+
+      fragment smallFoo on Foo {
+        id
+      }
+
+      fragment bigFoo on Foo {
+        id @simple(var0: $varA)
+        name @complex(arg0: $varB, arg1: $varC)
+      }
+    `;
+    expect(parseOperation(operation).variables).to.deep.eq(
+      new Set(['varA', 'varB', 'varC', 'varD'])
+    );
+  });
+
+});


### PR DESCRIPTION
The checks for unused variables were throwing for variables used exclusively within directives.

Tests included, non-breaking.