### PR TITLE
Fix field aliases when computing read completeness

### DIFF
--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -219,7 +219,8 @@ export function _visitSelection(
     }
 
     for (const field of fields) {
-      if (!(field.name.value in value)) {
+      const nameNode = field.alias || field.name;
+      if (!(nameNode.value in value)) {
         complete = false;
         break;
       }

--- a/src/util/tree.ts
+++ b/src/util/tree.ts
@@ -61,7 +61,8 @@ export function walkOperation(document: DocumentNode, result: JsonObject | undef
       if (selection.kind === 'Field') {
         fields.push(selection);
         if (selection.selectionSet) {
-          const child = get(parent, selection.name.value);
+          const nameNode = selection.alias || selection.name;
+          const child = get(parent, nameNode.value);
           stack.push(new OperationWalkNode(selection.selectionSet, child));
         }
 

--- a/test/unit/operations/read/incompletePayload.ts
+++ b/test/unit/operations/read/incompletePayload.ts
@@ -16,6 +16,7 @@ describe(`operations.read`, () => {
         messages(count: 2) {
           details
         }
+        seniority: tenure(unit: DAYS)
       }
       stopEtaSummary(limit: 2) {
         id
@@ -41,6 +42,7 @@ describe(`operations.read`, () => {
                 { details: 'Hello' },
                 { details: 'world' },
               ],
+              seniority: 10,
             },
             stopEtaSummary: [
               {
@@ -61,6 +63,7 @@ describe(`operations.read`, () => {
               messages: [
                 { details: 'Hello' },
               ],
+              seniority: 20,
             },
             stopEtaSummary: [
               {
@@ -94,6 +97,7 @@ describe(`operations.read`, () => {
                 { details: 'Hello' },
                 { details: 'world' },
               ],
+              seniority: 10,
             },
             stopEtaSummary: [
               {
@@ -114,6 +118,7 @@ describe(`operations.read`, () => {
               messages: [
                 { details: 'Hello' },
               ],
+              seniority: 20,
             },
             stopEtaSummary: [
               {
@@ -128,6 +133,7 @@ describe(`operations.read`, () => {
               name: null,
               id: null,
               messages: null,
+              seniority: null,
             },
             stopEtaSummary: null,
           },

--- a/test/unit/operations/read/incompletePayload.ts
+++ b/test/unit/operations/read/incompletePayload.ts
@@ -22,6 +22,9 @@ describe(`operations.read`, () => {
         id
         type
       }
+      vehicle: truck(index: 0) {
+        capacity
+      }
     }
   }`);
 
@@ -54,6 +57,9 @@ describe(`operations.read`, () => {
                 type: 'warning',
               },
             ],
+            vehicle: {
+              capacity: 100,
+            },
           },
           {
             id: '1',
@@ -71,6 +77,9 @@ describe(`operations.read`, () => {
                 type: 'warning',
               },
             ],
+            vehicle: {
+              capacity: 200,
+            },
           },
           {
             driver: {
@@ -109,6 +118,9 @@ describe(`operations.read`, () => {
                 type: 'warning',
               },
             ],
+            vehicle: {
+              capacity: 100,
+            },
           },
           {
             id: '1',
@@ -126,6 +138,9 @@ describe(`operations.read`, () => {
                 type: 'warning',
               },
             ],
+            vehicle: {
+              capacity: 200,
+            },
           },
           {
             id: null,
@@ -136,6 +151,7 @@ describe(`operations.read`, () => {
               seniority: null,
             },
             stopEtaSummary: null,
+            vehicle: null,
           },
         ],
       });


### PR DESCRIPTION
`walkOperation` and the general computation of read completeness were broken when it concerned complex fields with alias names. This patches a couple of gaps.

Tests included, non-breaking.