### PR TITLE
Add support for inline fragments

### DIFF
--- a/src/ParsedQueryNode.ts
+++ b/src/ParsedQueryNode.ts
@@ -152,8 +152,16 @@ function _buildNodeMap(
         }
       }
 
+    } else if (selection.kind === 'InlineFragment') {
+      const fragmentMap = _buildNodeMap(variables, context, fragments, selection.selectionSet, path);
+      if (fragmentMap) {
+        for (const name in fragmentMap) {
+          nodeMap[name] = _mergeNodes([...path, name], fragmentMap[name], nodeMap[name]);
+        }
+      }
+
     } else if (context.tracer.warning) {
-      context.tracer.warning(`${selection.kind} selections are not supported; query may misbehave`);
+      context.tracer.warning(`${(selection as any).kind} selections are not supported; query may misbehave`);
     }
 
     _collectDirectiveVariables(variables, selection);

--- a/test/unit/ParsedQueryNode/fragments.ts
+++ b/test/unit/ParsedQueryNode/fragments.ts
@@ -67,6 +67,31 @@ describe(`parseQuery for queries with fragments`, () => {
     });
   });
 
+  it(`parses queries with inline fragments`, () => {
+    const operation = `
+      query getThings {
+        foo {
+          ... on Foo {
+            id
+          }
+          ... on Bar {
+            id
+            name
+          }
+        }
+      }
+    `;
+    expect(parseOperation(operation)).to.deep.eq({
+      parsedQuery: {
+        foo: new ParsedQueryNode({
+          id: new ParsedQueryNode(),
+          name: new ParsedQueryNode(),
+        }),
+      },
+      variables: new Set(),
+    });
+  });
+
   it(`parses fragments with parameterized fields`, () => {
     const operation = `
       query getThings {

--- a/test/unit/operations/write/fragment/nestedValueUsingInlineFragment.ts
+++ b/test/unit/operations/write/fragment/nestedValueUsingInlineFragment.ts
@@ -1,0 +1,111 @@
+import { CacheContext } from '../../../../../src/context';
+import { GraphSnapshot } from '../../../../../src/GraphSnapshot';
+import { EntitySnapshot } from '../../../../../src/nodes';
+import { write } from '../../../../../src/operations/write';
+import { NodeId, StaticNodeId } from '../../../../../src/schema';
+import { query, strictConfig } from '../../../../helpers';
+
+const { QueryRoot: QueryRootId } = StaticNodeId;
+
+// These are really more like integration tests, given the underlying machinery.
+//
+// It just isn't very fruitful to unit test the individual steps of the write
+// workflow in isolation, given the contextual state that must be passed around.
+describe(`operations.write`, () => {
+
+  const context = new CacheContext(strictConfig);
+  const empty = new GraphSnapshot();
+
+  describe(`nested value with inline fragment`, () => {
+
+    let snapshot: GraphSnapshot, editedNodeIds: Set<NodeId>;
+    beforeAll(() => {
+      const viewerQuery = query(`
+        query getViewer {
+          viewer {
+            id
+            name
+            address {
+              ... on Address {
+                city
+                postal
+              }
+            }
+          }
+        }
+      `);
+
+      const result = write(context, empty, viewerQuery, {
+        viewer: {
+          id: 123,
+          name: 'Gouda',
+          address: {
+            city: 'seattle',
+            postal: '98090',
+          },
+        },
+      });
+      snapshot = result.snapshot;
+      editedNodeIds = result.editedNodeIds;
+    });
+
+    it(`creates the query root, referencing the entity`, () => {
+      jestExpect(snapshot.getNodeData(QueryRootId)).toEqual({
+        viewer: {
+          id: 123,
+          name: 'Gouda',
+          address: {
+            city: 'seattle',
+            postal: '98090',
+          },
+        },
+      });
+    });
+
+    it(`indexes the entity`, () => {
+      jestExpect(snapshot.getNodeData('123')).toEqual({
+        id: 123,
+        name: 'Gouda',
+        address: {
+          city: 'seattle',
+          postal: '98090',
+        },
+      });
+    });
+
+    it(`emits the root as an EntitySnapshot`, () => {
+      jestExpect(snapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+    });
+
+    it(`emits the entity as an EntitySnapshot`, () => {
+      jestExpect(snapshot.getNodeSnapshot('123')).toBeInstanceOf(EntitySnapshot);
+    });
+
+    it(`directly references viewer from the query root`, () => {
+      const queryRoot = snapshot.getNodeData(QueryRootId);
+      const viewer = snapshot.getNodeData('123');
+      jestExpect(queryRoot.viewer).toBe(viewer);
+    });
+
+    it(`records the outbound reference from the query root`, () => {
+      const queryRoot = snapshot.getNodeSnapshot(QueryRootId)!;
+      jestExpect(queryRoot.outbound).toEqual([{ id: '123', path: ['viewer'] }]);
+      jestExpect(queryRoot.inbound).toBe(undefined);
+    });
+
+    it(`records the inbound reference from referenced entity`, () => {
+      const queryRoot = snapshot.getNodeSnapshot('123')!;
+      jestExpect(queryRoot.inbound).toEqual([{ id: QueryRootId, path: ['viewer'] }]);
+      jestExpect(queryRoot.outbound).toBe(undefined);
+    });
+
+    it(`marks the entity and root as edited`, () => {
+      jestExpect(Array.from(editedNodeIds)).toEqual(jestExpect.arrayContaining([QueryRootId, '123']));
+    });
+
+    it(`only contains the two nodes`, () => {
+      jestExpect(snapshot.allNodeIds()).toEqual(jestExpect.arrayContaining([QueryRootId, '123']));
+    });
+  });
+
+});


### PR DESCRIPTION
Related to #153.

These simple changes add basic support for inline fragments (also known as union queries).

These changes were enough to make our app work, which makes heavy use of inline fragments and union types. Obviously, tests need to be written, but I'm not certain I'll have time to get to that any time soon, so I'm leaving my WIP here in case anybody would like to take over.

The only concern I have about this implementation is that I'm not inserting `nulls` per @nevir's guidance:

> When writing fields, any union field present in the payload should be written normally (except if not present, nulls shouldn't be inserted)