### PR TITLE
WIP: Add support for explicit static field via @static directive

### DIFF
--- a/src/ParsedQueryNode.ts
+++ b/src/ParsedQueryNode.ts
@@ -39,6 +39,10 @@ export class ParsedQueryNode<TArgTypes = JsonScalar> {
      * ignore whole subtrees in some situations if they were completely static.
      * */
     public hasParameterizedChildren?: true,
+    /**
+     * Whether the field is explicitly declared static via directive.
+     */
+    public isStatic?: true,
   ) {}
 }
 
@@ -124,9 +128,10 @@ function _buildNodeMap(
       const children = _buildNodeMap(variables, context, fragments, selection.selectionSet, [...path, name]);
       const schemaName = selection.alias ? selection.name.value : undefined;
       const args = _buildFieldArgs(variables, selection.arguments);
+      const isStatic = hasStaticDirective(selection);
       const hasParameterizedChildren = areChildrenDynamic(children);
 
-      const node = new ParsedQueryNode(children, schemaName, args, hasParameterizedChildren);
+      const node = new ParsedQueryNode(children, schemaName, args, hasParameterizedChildren, isStatic);
       nodeMap[name] = _mergeNodes([...path, name], node, nodeMap[name]);
 
     } else if (selection.kind === 'FragmentSpread') {
@@ -153,6 +158,16 @@ function _buildNodeMap(
 }
 
 /**
+ * Determine whether a given node is explicitly marked as static.
+ */
+function hasStaticDirective(node: SelectionNode) {
+  const { directives } = node;
+  if (!directives) return undefined;
+  if (directives.some(directive => directive.name.value === 'static')) return true;
+  return undefined;
+}
+
+/**
  * Well, are they?
  */
 export function areChildrenDynamic(children?: ParsedQueryWithVariables) {
@@ -160,8 +175,10 @@ export function areChildrenDynamic(children?: ParsedQueryWithVariables) {
   for (const name in children) {
     const child = children[name];
     if (child.hasParameterizedChildren) return true;
-    if (child.args) return true;
-    if (child.schemaName) return true; // Aliases are dynamic at read time.
+    if (!child.isStatic) {
+      if (child.args) return true;
+      if (child.schemaName) return true; // Aliases are dynamic at read time.
+    }
   }
   return undefined;
 }
@@ -260,6 +277,7 @@ export function _expandVariables(parsed?: ParsedQueryWithVariables, variables?: 
         node.schemaName,
         expandFieldArguments(node.args, variables),
         node.hasParameterizedChildren,
+        node.isStatic,
       );
     // No variables to substitute for this subtree.
     } else {

--- a/src/apollo/Queryable.ts
+++ b/src/apollo/Queryable.ts
@@ -1,6 +1,6 @@
 import { Cache, DataProxy } from 'apollo-cache';
-import { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies
 import { removeDirectivesFromDocument } from 'apollo-utilities';
+import { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies
 
 import { UnsatisfiedCacheError } from '../errors';
 import { JsonObject } from '../primitive';
@@ -84,7 +84,7 @@ export abstract class ApolloQueryable implements DataProxy {
   public transformForLink(document: DocumentNode): DocumentNode { // eslint-disable-line class-methods-use-this
     // @static directives are for the cache only.
     return removeDirectivesFromDocument(
-      [{name: 'static'}],
+      [{ name: 'static' }],
       document
     )!;
   }

--- a/src/apollo/Queryable.ts
+++ b/src/apollo/Queryable.ts
@@ -1,5 +1,6 @@
 import { Cache, DataProxy } from 'apollo-cache';
 import { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies
+import { removeDirectivesFromDocument } from 'apollo-utilities';
 
 import { UnsatisfiedCacheError } from '../errors';
 import { JsonObject } from '../primitive';
@@ -81,8 +82,11 @@ export abstract class ApolloQueryable implements DataProxy {
   }
 
   public transformForLink(document: DocumentNode): DocumentNode { // eslint-disable-line class-methods-use-this
-    // TODO: Actually transform it (and/or make it optional upstream).
-    return document;
+    // @static directives are for the cache only.
+    return removeDirectivesFromDocument(
+      [{name: 'static'}],
+      document
+    )!;
   }
 
   evict(options: Cache.EvictOptions): Cache.EvictionResult {

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -275,8 +275,8 @@ export class SnapshotEditor {
       // Similarly, the parameterized node contains an outbound reference to the
       // entity node, for garbage collection.
       let fieldPrefixPath = prefixPath;
-      let fieldPath = [...path, schemaName];
-      if (node.args) {
+      let fieldPath = [...path, node.isStatic ? payloadName : schemaName];
+      if (node.args && !node.isStatic) {
         // The values of a parameterized field are explicit nodes in the graph;
         // so we set up a new container & path.
         containerIdForField = this._ensureParameterizedValueSnapshot(containerId, fieldPath, node.args);

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -123,9 +123,9 @@ export function _walkAndOverlayDynamicValues(
       let fieldName = key;
 
       // This is an alias if we have a schemaName declared.
-      fieldName = node.schemaName ? node.schemaName : key;
+      fieldName = node.schemaName && !node.isStatic ? node.schemaName : key;
 
-      if (node.args) {
+      if (node.args && !node.isStatic) {
         let childId = nodeIdForParameterizedValue(containerId, [...path, fieldName], node.args);
         let childSnapshot = snapshot.getNodeSnapshot(childId);
         if (!childSnapshot) {


### PR DESCRIPTION
The read-time efficiency of Hermes increases when subtrees are fully static (i.e., when `areChildrenDynamic` returns `false`). Parameterized fields and aliases are considered dynamic, and if they occur deep within the tree, nearly the entire tree must be walked to fill these values in, significantly impacting performance.

In our use case, the mappings of field alias to dynamic field arguments is always stable. This is best illustrated by an example:

```graphql
fragment EpisodeDetails on Episode {
  id
  title
  author { ...UserDetails }
  myUpvotes: upvotes(owner: ME) { totalCount }
  allUpvotes: upvotes(owner: ANY) { totalCount }
}
```

In the above example, `myUpvotes` will **always** map to the `upvotes` field with the `owner: ME` argument. (The same goes for `allUpvotes`, but with a different argument.)

If we maintain this invariant, we can treat the aliased dynamic field the same as a static field and avoid the need to overlay it dynamically at read time. To signal this, I've introduce a client-only directive called `@static`.

To use the directive, you'd add it to the aliased dynamic field like such:

```
fragment EpisodeDetails on Episode {
  ...
  myUpvotes: upvotes(owner: ME) @static { totalCount }
  allUpvotes: upvotes(owner: ANY) @static { totalCount }
}
```

In a very unscientific benchmark, I've witnessed read-time materialization speeds increase by 20% on trees with deeply-nested `@static` fields.

More work remains to flesh this out as a feature. Specifically, we need to:

* [ ] Decide whether `@static` is the right name
* [ ] Decide whether these semantics have any obscure edge cases
* [ ] Write tests
* [ ] Add dev-mode warnings if the underlying field name or arguments change for a `@static`

Comments and contributions are welcome.