### PR TITLE
Only set --maxWorkers when we are NOT debugging

### DIFF
--- a/scripts/test-unit.sh
+++ b/scripts/test-unit.sh
@@ -23,17 +23,28 @@ for i in "${!FILES[@]}"; do
 done
 
 OPTIONS=(
-  --maxWorkers=2 --config ./test/unit/jest.json
+  --config ./test/unit/jest.json
 )
+DEBUGGING=false
+
 # Jest doesn't handle debugger flags directly.
 NODE_OPTIONS=()
 for option in "${OPTIONS_FLAGS[@]}"; do
-  if [[ "${option}" =~ ^--(inspect|debug-brk|nolazy) ]]; then
+  if [[ "${option}" =~ ^--(debug-brk) ]]; then
+    DEBUGGING=true
+    NODE_OPTIONS+=("${option}")
+  elif [[ "${option}" =~ ^--(inspect|nolazy) ]]; then
     NODE_OPTIONS+=("${option}")
   else
     OPTIONS+=("${option}")
   fi
 done
+
+# --runInBand and --maxWorkers can't work together
+# only set --maxWorkers if we are not debugging and vice versa
+if [ "$DEBUGGING" == false ]; then
+  OPTIONS+=("--maxWorkers=2")
+fi
 
 # For jest-junit
 export JEST_SUITE_NAME="test-unit"

--- a/scripts/test-unit.sh
+++ b/scripts/test-unit.sh
@@ -30,10 +30,10 @@ DEBUGGING=false
 # Jest doesn't handle debugger flags directly.
 NODE_OPTIONS=()
 for option in "${OPTIONS_FLAGS[@]}"; do
-  if [[ "${option}" =~ ^--(debug-brk) ]]; then
+  if [[ "${option}" =~ ^--(inspect|debug-brk) ]]; then
     DEBUGGING=true
     NODE_OPTIONS+=("${option}")
-  elif [[ "${option}" =~ ^--(inspect|nolazy) ]]; then
+  elif [[ "${option}" =~ ^--(nolazy) ]]; then
     NODE_OPTIONS+=("${option}")
   else
     OPTIONS+=("${option}")


### PR DESCRIPTION
This is to set maximum number of workers when running the unit test. I was doing this because I keep running into out-of-memory error. But `--maxWorkers` and `--runInBands` don't work together so we have to check if we are in debugging or not