### PR TITLE
ApolloQuerable extends ApolloCache directly instead of implements DataProxy

### DIFF
--- a/src/apollo/Hermes.ts
+++ b/src/apollo/Hermes.ts
@@ -15,7 +15,7 @@ import { toQuery } from './util';
 /**
  * Apollo-specific interface to the cache.
  */
-export class Hermes extends ApolloQueryable implements ApolloCache<GraphSnapshot> {
+export class Hermes extends ApolloQueryable<GraphSnapshot> {
   /** The underlying Hermes cache. */
   protected _queryable: Cache;
 

--- a/src/apollo/Queryable.ts
+++ b/src/apollo/Queryable.ts
@@ -1,4 +1,4 @@
-import { Cache, DataProxy } from 'apollo-cache';
+import { ApolloCache, Cache, DataProxy } from 'apollo-cache';
 import { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies
 
 import { JsonObject } from '../primitive';
@@ -9,7 +9,7 @@ import { toQuery } from './util';
 /**
  * Apollo-specific interface to the cache.
  */
-export abstract class ApolloQueryable implements DataProxy {
+export abstract class ApolloQueryable<TSerialized> extends ApolloCache<TSerialized> {
   /** The underlying Hermes cache. */
   protected abstract _queryable: Queryable;
 

--- a/src/apollo/Transaction.ts
+++ b/src/apollo/Transaction.ts
@@ -8,7 +8,7 @@ import { ApolloQueryable } from './Queryable';
 /**
  * Apollo-specific transaction interface.
  */
-export class ApolloTransaction extends ApolloQueryable implements ApolloCache<GraphSnapshot> {
+export class ApolloTransaction extends ApolloQueryable<GraphSnapshot> {
 
   constructor(
     /** The underlying transaction. */


### PR DESCRIPTION
While trying to understanding the relationship between `Hermes`, `ApolloTransaction` and `ApolloQuerable`, I think we can have `ApolloQueryable extends from `ApolloCache` directly and implements specify methods such as diff, read etc.

Picture of my understanding -> let me know if I miss anything here
![hermes_inheritance](https://user-images.githubusercontent.com/489742/32026327-ba7063a4-b998-11e7-930c-f40fd1397af4.png)

