### PR TITLE
use isNil instead of explicit null check

### DIFF
--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -145,7 +145,7 @@ export function _walkAndOverlayDynamicValues(
       }
 
       // Have we reached a leaf (either in the query, or in the cache)?
-      if (node.hasParameterizedChildren && node.children && child !== null) {
+      if (node.hasParameterizedChildren && node.children && !isNil(child)) {
         if (Array.isArray(child)) {
           child = [...child];
           for (let i = child.length - 1; i >= 0; i--) {

--- a/test/unit/operations/read/partialResultInCache.ts
+++ b/test/unit/operations/read/partialResultInCache.ts
@@ -1,0 +1,81 @@
+import { CacheContext } from '../../../../src/context';
+import { QueryResult, read } from '../../../../src/operations';
+import { query, silentConfig, createGraphSnapshot, createStrictCacheContext } from '../../../helpers';
+
+describe(`operations.read`, () => {
+
+  const context = new CacheContext(silentConfig);
+  const readQuery = query(`
+  query getShipment($id: ID!) {
+    shipments(id: $id) {
+      id
+      driver {
+        id
+        name
+      }
+      charges {
+        lineItems {
+          id
+          User: sourceUser {
+            id
+            name
+          }
+        }
+      }
+    }
+  }`, { id: 0 });
+
+  describe(`partial result in cache`, () => {
+
+    let readResult: QueryResult;
+
+    beforeAll(() => {
+
+      const cacheContext = createStrictCacheContext();
+      const snapshot = createGraphSnapshot(
+        {
+          shipments: [{
+            id: '0',
+            driver: {
+              id: 'Bob-d0',
+              name: 'Bob',
+            },
+          }],
+        },
+        `query getShipment($id: ID!) {
+          shipments(id: $id) {
+            id
+            driver {
+              id
+              name
+            }
+          }
+        }`,
+        cacheContext,
+        { id: 0 }
+      );
+      readResult = read(context, readQuery, snapshot);
+    });
+
+    it(`verify that read result is not complete`, () => {
+      expect(readResult.complete).to.eq(false);
+    });
+
+    it(`verify that read result is correct`, () => {
+      expect(readResult.result).to.deep.eq({
+        shipments: [
+          {
+            id: '0',
+            driver: {
+              id: 'Bob-d0',
+              name: 'Bob',
+            },
+            charges: undefined,
+          },
+        ],
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
I was seeing an issue where for an object in the cache (e.g. shipment with id=0), when trying to request data on that shipment that wasn't yet in the cache (e.g. `shipment.charges` where `charges` is not in the cache because it's an additional fragment that wasn't originally requested when pulling down shipment with id=0), the cache was filling in data (including an object with all fields undefined when an array was expected for charges) instead of aborting the query traversal once a property was encountered that was not in the cache. This change seemed to fix it for me. I have not wrapped my head around this code yet, so let me know if what I'm doing is dumb and the problem is elsewhere.