### PR TITLE
Add onChange callback in cache configuration

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -124,6 +124,10 @@ export class Cache implements Queryable {
     const { snapshot, editedNodeIds } = transaction.commit();
     this._setSnapshot(snapshot, editedNodeIds);
 
+    // Call the on-change callback here to notify any change
+    if (this._context.onChange && typeof this._context.onChange === 'function') {
+      this._context.onChange(this._snapshot, editedNodeIds);
+    }
     return true;
   }
 

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -32,11 +32,7 @@ export class Cache implements Queryable {
 
   constructor(config?: CacheContext.Configuration) {
     const initialGraphSnapshot = new GraphSnapshot();
-    this._snapshot = {
-      baseline: initialGraphSnapshot,
-      optimistic: initialGraphSnapshot,
-      optimisticQueue: new OptimisticUpdateQueue(),
-    };
+    this._snapshot = new CacheSnapshot(initialGraphSnapshot, initialGraphSnapshot, new OptimisticUpdateQueue());
     this._context = new CacheContext(config);
   }
 

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -32,7 +32,11 @@ export class Cache implements Queryable {
 
   constructor(config?: CacheContext.Configuration) {
     const initialGraphSnapshot = new GraphSnapshot();
-    this._snapshot = new CacheSnapshot(initialGraphSnapshot, initialGraphSnapshot, new OptimisticUpdateQueue());
+    this._snapshot = {
+      baseline: initialGraphSnapshot,
+      optimistic: initialGraphSnapshot,
+      optimisticQueue: new OptimisticUpdateQueue(),
+    };
     this._context = new CacheContext(config);
   }
 

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -144,7 +144,7 @@ export class Cache implements Queryable {
     const optimistic = baseline;
     const optimisticQueue = new OptimisticUpdateQueue();
 
-    this._setSnapshot({ baseline, optimistic, optimisticQueue }, allIds);
+    this._setSnapshot(new CacheSnapshot(baseline, optimistic, optimisticQueue), allIds);
   }
 
   // Internal

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -124,10 +124,6 @@ export class Cache implements Queryable {
     const { snapshot, editedNodeIds } = transaction.commit();
     this._setSnapshot(snapshot, editedNodeIds);
 
-    // Call the on-change callback here to notify any change
-    if (this._context.onChange && typeof this._context.onChange === 'function') {
-      this._context.onChange(this._snapshot, editedNodeIds);
-    }
     return true;
   }
 
@@ -168,12 +164,17 @@ export class Cache implements Queryable {
 
   /**
    * Point the cache to a new snapshot, and let observers know of the change.
+   * Call onChange callback if one exist to notify cache users of any change.
    */
   private _setSnapshot(snapshot: CacheSnapshot, editedNodeIds: Set<NodeId>): void {
     this._snapshot = snapshot;
 
     for (const observer of this._observers) {
       observer.consumeChanges(snapshot.optimistic, editedNodeIds);
+    }
+
+    if (this._context.onChange) {
+      this._context.onChange(this._snapshot, editedNodeIds);
     }
   }
 

--- a/src/CacheSnapshot.ts
+++ b/src/CacheSnapshot.ts
@@ -4,13 +4,11 @@ import { OptimisticUpdateQueue } from './OptimisticUpdateQueue';
 /**
  * Maintains an immutable, point-in-time view of the cache.
  */
-export class CacheSnapshot {
-  constructor(
-    /** The base snapshot for this version of the cache. */
-    public baseline: GraphSnapshot,
-    /** The optimistic view of this version of this cache (may be base). */
-    public optimistic: GraphSnapshot,
-    /** Individual optimistic updates for this version. */
-    public optimisticQueue: OptimisticUpdateQueue,
-  ) {}
+export interface CacheSnapshot {
+  /** The base snapshot for this version of the cache. */
+  baseline: GraphSnapshot;
+  /** The optimistic view of this version of this cache (may be base). */
+  optimistic: GraphSnapshot;
+  /** Individual optimistic updates for this version. */
+  optimisticQueue: OptimisticUpdateQueue;
 }

--- a/src/CacheSnapshot.ts
+++ b/src/CacheSnapshot.ts
@@ -4,11 +4,13 @@ import { OptimisticUpdateQueue } from './OptimisticUpdateQueue';
 /**
  * Maintains an immutable, point-in-time view of the cache.
  */
-export interface CacheSnapshot {
-  /** The base snapshot for this version of the cache. */
-  baseline: GraphSnapshot;
-  /** The optimistic view of this version of this cache (may be base). */
-  optimistic: GraphSnapshot;
-  /** Individual optimistic updates for this version. */
-  optimisticQueue: OptimisticUpdateQueue;
+export class CacheSnapshot {
+  constructor(
+    /** The base snapshot for this version of the cache. */
+    public baseline: GraphSnapshot,
+    /** The optimistic view of this version of this cache (may be base). */
+    public optimistic: GraphSnapshot,
+    /** Individual optimistic updates for this version. */
+    public optimisticQueue: OptimisticUpdateQueue,
+  ) {}
 }

--- a/src/CacheSnapshot.ts
+++ b/src/CacheSnapshot.ts
@@ -3,6 +3,10 @@ import { OptimisticUpdateQueue } from './OptimisticUpdateQueue';
 
 /**
  * Maintains an immutable, point-in-time view of the cache.
+ *
+ * We make CacheSnapshot a class instead of an interface because
+ * to garuntee consistentcy of properties and their order. This
+ * improves performance as JavaScript VM can do better optimization.
  */
 export class CacheSnapshot {
   constructor(

--- a/src/CacheTransaction.ts
+++ b/src/CacheTransaction.ts
@@ -75,7 +75,7 @@ export class CacheTransaction implements Queryable {
     const optimisticQueue = current.optimisticQueue.remove(changeId);
     const optimistic = this._buildOptimisticSnapshot(current.baseline);
 
-    this._snapshot = { ...current, optimistic, optimisticQueue };
+    this._snapshot = new CacheSnapshot(current.baseline, optimistic, optimisticQueue);
   }
 
   /**
@@ -159,7 +159,7 @@ export class CacheTransaction implements Queryable {
 
     const optimistic = this._buildOptimisticSnapshot(baseline);
 
-    this._snapshot = { ...current, baseline, optimistic };
+    this._snapshot = new CacheSnapshot(baseline, optimistic, current.optimisticQueue);
   }
 
   /**
@@ -185,7 +185,7 @@ export class CacheTransaction implements Queryable {
     addToSet(this._writtenQueries, writtenQueries);
     addToSet(this._editedNodeIds, editedNodeIds);
 
-    this._snapshot = { ...this._snapshot, optimistic };
+    this._snapshot = new CacheSnapshot(this._snapshot.baseline, optimistic, this._snapshot.optimisticQueue);
   }
 
 }

--- a/src/CacheTransaction.ts
+++ b/src/CacheTransaction.ts
@@ -95,10 +95,11 @@ export class CacheTransaction implements Queryable {
 
     let snapshot = this._snapshot;
     if (this._optimisticChangeId) {
-      snapshot = {
-        ...snapshot,
-        optimisticQueue: snapshot.optimisticQueue.enqueue(this._optimisticChangeId, this._deltas),
-      };
+      snapshot = new CacheSnapshot(
+        snapshot.baseline,
+        snapshot.optimistic,
+        snapshot.optimisticQueue.enqueue(this._optimisticChangeId, this._deltas),
+      );
     }
 
     return { snapshot, editedNodeIds: this._editedNodeIds, writtenQueries: this._writtenQueries };

--- a/src/apollo/Hermes.ts
+++ b/src/apollo/Hermes.ts
@@ -5,6 +5,7 @@ import {
 } from 'apollo-cache';
 
 import { Cache } from '../Cache';
+import { CacheSnapshot } from '../CacheSnapshot';
 import { CacheContext } from '../context';
 import { GraphSnapshot } from '../GraphSnapshot';
 
@@ -53,5 +54,9 @@ export class Hermes extends ApolloQueryable implements ApolloCache<GraphSnapshot
   watch(options: CacheInterface.WatchOptions): () => void {
     const query = toQuery(options.query, options.variables, options.rootId);
     return this._queryable.watch(query, options.callback);
+  }
+
+  getCacheSnapshot(): CacheSnapshot {
+    return this._queryable.getSnapshot();
   }
 }

--- a/src/apollo/Hermes.ts
+++ b/src/apollo/Hermes.ts
@@ -56,7 +56,7 @@ export class Hermes extends ApolloQueryable implements ApolloCache<GraphSnapshot
     return this._queryable.watch(query, options.callback);
   }
 
-  getCacheSnapshot(): CacheSnapshot {
+  getCurrentCacheSnapshot(): CacheSnapshot {
     return this._queryable.getSnapshot();
   }
 }

--- a/src/context/CacheContext.ts
+++ b/src/context/CacheContext.ts
@@ -19,7 +19,7 @@ export namespace CacheContext {
   export type EntityIdMapper = (node: JsonObject) => string | number | undefined;
   export type EntityTransformer = (node: JsonObject) => void;
   export type LogEmitter = (message: string, ...metadata: any[]) => void;
-  export type OnChangeCallBack = (newCacheShapshot: CacheSnapshot, editedNodeIds: Set<String>) => void;
+  export type OnChangeCallback = (newCacheShapshot: CacheSnapshot, editedNodeIds: Set<String>) => void;
 
   export interface Logger {
     debug: LogEmitter;
@@ -124,7 +124,7 @@ export namespace CacheContext {
      * This allow the cache to be integrated with external tools such as Redux.
      * It allows other tools to be notified when there are changes.
      */
-    onChange?: OnChangeCallBack;
+    onChange?: OnChangeCallback;
   }
 
 }
@@ -153,7 +153,7 @@ export class CacheContext {
   readonly entityUpdaters: CacheContext.EntityUpdaters;
 
   /** Configured on-change callback */
-  readonly onChange: CacheContext.OnChangeCallBack | undefined;
+  readonly onChange: CacheContext.OnChangeCallback | undefined;
 
   /** Whether __typename should be injected into nodes in queries. */
   private readonly _addTypename: boolean;

--- a/test/unit/context/CacheContext/entityUpdaters.ts
+++ b/test/unit/context/CacheContext/entityUpdaters.ts
@@ -2,8 +2,8 @@ import { Cache } from '../../../../src';
 import { CacheContext } from '../../../../src/context';
 import { query, strictConfig } from '../../../helpers';
 
-describe(`operations.read`, () => {
-  describe(`with entity updaters`, () => {
+describe(`context.CacheContext`, () => {
+  describe(` entity updaters`, () => {
 
     const activeUsersQuery = query(`{
       activeUsers { __typename id name active }

--- a/test/unit/context/CacheContext/onChange.ts
+++ b/test/unit/context/CacheContext/onChange.ts
@@ -1,0 +1,133 @@
+import { Cache } from '../../../../src';
+import { GraphSnapshot } from '../../../../src/GraphSnapshot';
+import { EntitySnapshot } from '../../../../src/nodes/EntitySnapshot';
+import { OptimisticUpdateQueue } from '../../../../src/OptimisticUpdateQueue';
+import { StaticNodeId } from '../../../../src/schema';
+import { query, strictConfig } from '../../../helpers';
+
+const { QueryRoot: QueryRootId } = StaticNodeId;
+
+describe(`context.CacheContext`, () => {
+  describe(`onChange callback`, () => {
+    const mockOnChange = jest.fn();
+    const graphqlQuery = query(`{
+      foo {
+        id
+        bar {
+          id
+          name
+        }
+      }
+    }`);
+
+    const cache = new Cache({ ...strictConfig, onChange: mockOnChange });
+
+    it(`trigger onChange callback when write to cache`, () => {
+      cache.write(
+        graphqlQuery,
+        {
+          foo: {
+            id: 0,
+            bar: {
+              id: 1,
+              name: 'Gouda',
+            },
+          },
+        }
+      );
+
+      const bar = { id: 1, name: 'Gouda' };
+      const foo = {
+        id: 0,
+        bar,
+      };
+
+      const _values = {
+        '0': new EntitySnapshot(
+          foo,
+          /* inbound */ [{ id: QueryRootId, path: ['foo'] }],
+          /* outbound */ [{ id: '1', path: ['bar'] }],
+        ),
+        '1': new EntitySnapshot(
+          bar,
+          /* inbound */ [{ id: '0', path: ['bar'] }],
+          /* outbound */ undefined,
+        ),
+        [QueryRootId]: new EntitySnapshot(
+          {
+            foo,
+          },
+          /* inbound */ undefined,
+          /* outbound */ [{ id: '0', path: ['foo'] }],
+        ),
+      };
+
+      expect(mockOnChange.mock.calls.length).to.equal(1);
+      expect(mockOnChange.mock.calls[0][0]).to.deep.equal({
+        baseline: new GraphSnapshot(_values),
+        optimistic: new GraphSnapshot(_values),
+        optimisticQueue: new OptimisticUpdateQueue(),
+      });
+      expect(mockOnChange.mock.calls[0][1]).to.deep.equal(new Set([QueryRootId, '0', '1']));
+      mockOnChange.mockClear();
+    });
+
+    it(`trigger onChange callback when write with transaction`, () => {
+      cache.transaction((transaction) => {
+        transaction.write(
+          graphqlQuery,
+          {
+            foo: {
+              id: 0,
+              bar: {
+                id: 1,
+                name: 'Munster',
+              },
+            },
+          }
+        );
+      });
+
+      const bar = { id: 1, name: 'Munster' };
+      const foo = {
+        id: 0,
+        bar,
+      };
+
+      const _values = {
+        '0': new EntitySnapshot(
+          foo,
+          /* inbound */ [{ id: QueryRootId, path: ['foo'] }],
+          /* outbound */ [{ id: '1', path: ['bar'] }],
+        ),
+        '1': new EntitySnapshot(
+          bar,
+          /* inbound */ [{ id: '0', path: ['bar'] }],
+          /* outbound */ undefined,
+        ),
+        [QueryRootId]: new EntitySnapshot(
+          {
+            foo,
+          },
+          /* inbound */ undefined,
+          /* outbound */ [{ id: '0', path: ['foo'] }],
+        ),
+      };
+
+      expect(mockOnChange.mock.calls.length).to.equal(1);
+      expect(mockOnChange.mock.calls[0][0]).to.deep.equal({
+        baseline: new GraphSnapshot(_values),
+        optimistic: new GraphSnapshot(_values),
+        optimisticQueue: new OptimisticUpdateQueue(),
+      });
+      expect(mockOnChange.mock.calls[0][1]).to.deep.equal(new Set(['1']));
+      mockOnChange.mockClear();
+    });
+
+    it(`do not trigger onChange callback on read`, () => {
+      cache.read(graphqlQuery);
+      expect(mockOnChange.mock.calls.length).to.equal(0);
+    });
+
+  });
+});

--- a/test/unit/context/CacheContext/onChangeWithError.ts
+++ b/test/unit/context/CacheContext/onChangeWithError.ts
@@ -1,0 +1,48 @@
+import { Cache } from '../../../../src';
+import { query } from '../../../helpers';
+
+describe(`context.CacheContext`, () => {
+  describe(`onChange callback on error`, () => {
+    const mockOnChange = jest.fn();
+    const graphqlQuery = query(`{
+      foo {
+        id
+        bar {
+          id
+          name
+        }
+      }
+    }`);
+
+    const cache = new Cache({
+      logger: {
+        debug: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        group: jest.fn(),
+        groupEnd: jest.fn(),
+      },
+      onChange: mockOnChange,
+    });
+
+    it(`do not trigger onChange callback on error`, () => {
+      cache.transaction((transaction) => {
+        transaction.write(
+          graphqlQuery,
+          {
+            foo: {
+              id: 0,
+              bar: {
+                id: 1,
+                name: 'Gouda',
+              },
+            },
+          }
+        );
+        throw new Error(`Fake error`);
+      });
+      expect(mockOnChange.mock.calls.length).to.equal(0);
+    });
+
+  });
+});


### PR DESCRIPTION
Add onChange to cache configuration API to allow users to perform tasks such as dispatch redux action when there is a change in the cache or log the update etc.