### PR TITLE
Move logging into a formal tracing interface

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -117,7 +117,7 @@ export class Cache implements Queryable {
     try {
       callback(transaction);
     } catch (error) {
-      this._context.error(`Rolling back transaction due to error:`, error);
+      this._context.warn(`Rolling transaction back due to error:`, error);
       return false;
     }
 

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -171,12 +171,21 @@ export class Cache implements Queryable {
   private _setSnapshot(snapshot: CacheSnapshot, editedNodeIds: Set<NodeId>): void {
     this._snapshot = snapshot;
 
+    let tracerContext;
+    if (this._context.tracer.broadcastStart) {
+      tracerContext = this._context.tracer.broadcastStart({ snapshot, editedNodeIds })
+    }
+
     for (const observer of this._observers) {
       observer.consumeChanges(snapshot.optimistic, editedNodeIds);
     }
 
     if (this._context.onChange) {
       this._context.onChange(this._snapshot, editedNodeIds);
+    }
+
+    if (this._context.tracer.broadcastEnd) {
+      this._context.tracer.broadcastEnd({ snapshot, editedNodeIds }, tracerContext);
     }
   }
 

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -117,7 +117,9 @@ export class Cache implements Queryable {
     try {
       callback(transaction);
     } catch (error) {
-      this._context.warn(`Rolling transaction back due to error:`, error);
+      if (this._context.tracer.warning) {
+        this._context.tracer.warning(`Rolling transaction back due to error:`, error);
+      }
       return false;
     }
 

--- a/src/ParsedQueryNode.ts
+++ b/src/ParsedQueryNode.ts
@@ -142,8 +142,8 @@ function _buildNodeMap(
         }
       }
 
-    } else {
-      context.warn(`${selection.kind} selections are not supported; query may misbehave`);
+    } else if (context.tracer.warning) {
+      context.tracer.warning(`${selection.kind} selections are not supported; query may misbehave`);
     }
 
     _collectDirectiveVariables(variables, selection);

--- a/src/context/CacheContext.ts
+++ b/src/context/CacheContext.ts
@@ -179,6 +179,7 @@ export class CacheContext {
     this._addTypename = config.addTypename || false;
     this._logger = config.logger || {
       debug: _makeDefaultLogger('debug'),
+      info:  _makeDefaultLogger('info'),
       warn:  _makeDefaultLogger('warn'),
       // Grouping:
       group: _makeDefaultLogger('group'),

--- a/src/context/CacheContext.ts
+++ b/src/context/CacheContext.ts
@@ -24,7 +24,6 @@ export namespace CacheContext {
   export interface Logger {
     debug: LogEmitter;
     warn: LogEmitter;
-    error: LogEmitter;
     group: LogEmitter;
     groupEnd: () => void;
   }
@@ -179,7 +178,6 @@ export class CacheContext {
     this._logger = config.logger || {
       debug: _makeDefaultLogger('debug'),
       warn:  _makeDefaultLogger('warn'),
-      error: _makeDefaultLogger('error'),
       // Grouping:
       group: _makeDefaultLogger('group'),
       groupEnd: console.groupEnd ? console.groupEnd.bind(console) : () => {}, // eslint-disable-line no-console
@@ -250,13 +248,6 @@ export class CacheContext {
   }
 
   /**
-   * Emit a non-blocking error.
-   */
-  error(message: string, ...metadata: any[]): void {
-    this._logger.error(message, ...metadata);
-  }
-
-  /**
    * Emit log events in a (collapsed) group.
    */
   logGroup(message: string, callback: () => void): void {
@@ -306,7 +297,7 @@ export function operationCacheKey(document: DocumentNode) {
   return document.loc!.source.body;
 }
 
-function _makeDefaultLogger(level: 'debug' | 'info' | 'warn' | 'error' | 'group') {
+function _makeDefaultLogger(level: 'debug' | 'info' | 'warn' | 'group') {
   const method = console[level] || console.log; // eslint-disable-line no-console
   return function defaultLogger(message: string, ...args: any[]) {
     method.call(console, `[Cache] ${message}`, ...args);

--- a/src/context/CacheContext.ts
+++ b/src/context/CacheContext.ts
@@ -106,7 +106,10 @@ export namespace CacheContext {
     onChange?: OnChangeCallback;
 
     /**
-     * TODO:
+     * The tracer to instrument the cache with.
+     *
+     * If not supplied, a ConsoleTracer will be constructed, with `verbose` and
+     * `logger` passed as its arguments.
      */
     tracer?: Tracer;
 
@@ -115,11 +118,15 @@ export namespace CacheContext {
      *
      * Enabling this will cause the cache to emit log events for most operations
      * performed against it.
+     *
+     * Ignored if `tracer` is supplied.
      */
     verbose?: boolean;
 
     /**
      * The logger to use when emitting messages. By default, `console`.
+     *
+     * Ignored if `tracer` is supplied.
      */
     logger?: ConsoleTracer.Logger;
   }

--- a/src/context/CacheContext.ts
+++ b/src/context/CacheContext.ts
@@ -236,14 +236,6 @@ export class CacheContext {
   }
 
   /**
-   * Emit a debugging message.
-   */
-  debug(message: string, ...metadata: any[]): void {
-    if (!this.verbose) return;
-    this._logger.debug(message, ...metadata);
-  }
-
-  /**
    * Emit log events in a (collapsed) group.
    */
   logGroup(message: string, callback: () => void): void {

--- a/src/context/CacheContext.ts
+++ b/src/context/CacheContext.ts
@@ -152,6 +152,9 @@ export class CacheContext {
   /** Configured on-change callback */
   readonly onChange: CacheContext.OnChangeCallback | undefined;
 
+  /** The tracer we should use. */
+  readonly tracer: Tracer;
+
   /** Whether __typename should be injected into nodes in queries. */
   private readonly _addTypename: boolean;
   /** All currently known & processed GraphQL documents. */
@@ -160,8 +163,6 @@ export class CacheContext {
   private readonly _operationMap = new Map<string, OperationInstance[]>();
   /** The logger we should use. */
   private readonly _logger: ConsoleTracer.Logger;
-  /** The tracer we should use. */
-  private readonly _tracer: Tracer;
 
   constructor(config: CacheContext.Configuration = {}) {
     this.entityIdForValue = _makeEntityIdMapper(config.entityIdForNode);
@@ -173,9 +174,9 @@ export class CacheContext {
     this.resolverRedirects = config.resolverRedirects || {};
     this.onChange = config.onChange;
     this.entityUpdaters = config.entityUpdaters || {};
+    this.tracer = config.tracer || new ConsoleTracer(!!config.verbose, config.logger);
 
     this._addTypename = config.addTypename || false;
-    this._tracer = config.tracer || new ConsoleTracer(!!config.verbose, config.logger);
     this._logger = config.logger || {
       debug: _makeDefaultLogger('debug'),
       warn:  _makeDefaultLogger('warn'),
@@ -239,14 +240,6 @@ export class CacheContext {
   debug(message: string, ...metadata: any[]): void {
     if (!this.verbose) return;
     this._logger.debug(message, ...metadata);
-  }
-
-  /**
-   * Emit a warning.
-   */
-  warn(message: string, ...metadata: any[]): void {
-    if (!this._tracer.warning) return;
-    this._tracer.warning(message, ...metadata);
   }
 
   /**

--- a/src/context/ConsoleTracer.ts
+++ b/src/context/ConsoleTracer.ts
@@ -1,0 +1,51 @@
+import { Tracer } from '../tracing/Tracer';
+
+/**
+ * The default tracer used by the cache.
+ *
+ * By default it logs only warnings, but a verbose mode can be enabled to log
+ * out all cache operations.
+ */
+export class ConsoleTracer implements Tracer {
+
+  constructor(
+    private _verbose: boolean,
+    private _logger: ConsoleTracer.Logger = ConsoleTracer.DefaultLogger,
+  ) {}
+
+  warning(message: string, ...metadata: any[]) {
+    if (this._verbose) return;
+    this._logger.warn(message, ...metadata);
+  }
+
+}
+
+export namespace ConsoleTracer {
+  export type LogEmitter = (message: string, ...metadata: any[]) => void;
+
+  /**
+   * The minimal implementation of a logger required for ConsoleTracer to
+   * perform its duties.  This is a slimmed down interface for Console.
+   */
+  export interface Logger {
+    debug: LogEmitter;
+    warn: LogEmitter;
+    group: LogEmitter;
+    groupEnd: () => void;
+  }
+
+  export const DefaultLogger: Logger = {
+    debug: _makeDefaultEmitter('debug'),
+    warn:  _makeDefaultEmitter('warn'),
+    // Grouping:
+    group: _makeDefaultEmitter('group'),
+    groupEnd: console.groupEnd ? console.groupEnd.bind(console) : () => {}, // eslint-disable-line no-console
+  };
+}
+
+function _makeDefaultEmitter(level: 'debug' | 'info' | 'warn' | 'group') {
+  const method = console[level] || console.log; // eslint-disable-line no-console
+  return function defaultLogger(message: string, ...args: any[]) {
+    method.call(console, `[Cache] ${message}`, ...args);
+  };
+}

--- a/src/context/ConsoleTracer.ts
+++ b/src/context/ConsoleTracer.ts
@@ -30,9 +30,23 @@ export class ConsoleTracer implements Tracer<void> {
     }
   }
 
-  writeEnd(operation: OperationInstance, payload: JsonObject, newSnapshot: EditedSnapshot) {
+  writeEnd(operation: OperationInstance, result: Tracer.WriteResult) {
     if (!this._verbose) return;
-    this._logger.debug(this.formatOperation('write', operation), { payload, newSnapshot });
+    const { payload, newSnapshot, warnings } = result;
+    const message = this.formatOperation('write', operation);
+
+    // Extended logging for writes that trigger warnings.
+    if (warnings) {
+      this._logger.group(message);
+      this._logger.warn('payload with warnings:', payload);
+      for (const warning of warnings) {
+        this._logger.warn(warning);
+      }
+      this._logger.debug('new snapshot:', newSnapshot);
+      this._logger.groupEnd();
+    } else {
+      this._logger.debug(message, { payload, newSnapshot });
+    }
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/src/context/ConsoleTracer.ts
+++ b/src/context/ConsoleTracer.ts
@@ -1,6 +1,3 @@
-import { QueryResult } from '../operations/read';
-import { EditedSnapshot } from '../operations/SnapshotEditor';
-import { JsonObject } from '../primitive';
 import { OperationInstance } from '../schema';
 
 import { Tracer } from './Tracer';
@@ -23,13 +20,13 @@ export class ConsoleTracer implements Tracer<void> {
     this._logger.warn(message, ...metadata);
   }
 
-  readEnd(operation: OperationInstance, result: QueryResult, cacheHit: boolean) {
+  readEnd(operation: OperationInstance, result: Tracer.ReadResult) {
     if (!this._verbose) return;
     const message = this.formatOperation('read', operation);
-    if (cacheHit) {
-      this._logger.debug(`${message} (cached)`, result);
+    if (result.cacheHit) {
+      this._logger.debug(`${message} (cached)`, result.result);
     } else {
-      this._logger.info(message, result);
+      this._logger.info(message, result.result);
     }
   }
 

--- a/src/context/ConsoleTracer.ts
+++ b/src/context/ConsoleTracer.ts
@@ -1,4 +1,4 @@
-import { Tracer } from '../tracing/Tracer';
+import { Tracer } from './Tracer';
 
 /**
  * The default tracer used by the cache.

--- a/src/context/ConsoleTracer.ts
+++ b/src/context/ConsoleTracer.ts
@@ -20,19 +20,19 @@ export class ConsoleTracer implements Tracer<void> {
     this._logger.warn(message, ...metadata);
   }
 
-  readEnd(operation: OperationInstance, result: Tracer.ReadResult) {
+  readEnd(operation: OperationInstance, info: Tracer.ReadInfo) {
     if (!this._verbose) return;
     const message = this.formatOperation('read', operation);
-    if (result.cacheHit) {
-      this._logger.debug(`${message} (cached)`, result.result);
+    if (info.cacheHit) {
+      this._logger.debug(`${message} (cached)`, info.result);
     } else {
-      this._logger.info(message, result.result);
+      this._logger.info(message, info.result);
     }
   }
 
-  writeEnd(operation: OperationInstance, result: Tracer.WriteResult) {
+  writeEnd(operation: OperationInstance, info: Tracer.WriteInfo) {
     if (!this._verbose) return;
-    const { payload, newSnapshot, warnings } = result;
+    const { payload, newSnapshot, warnings } = info;
     const message = this.formatOperation('write', operation);
 
     // Extended logging for writes that trigger warnings.

--- a/src/context/ConsoleTracer.ts
+++ b/src/context/ConsoleTracer.ts
@@ -1,4 +1,6 @@
 import { QueryResult } from '../operations/read';
+import { EditedSnapshot } from '../operations/SnapshotEditor';
+import { JsonObject } from '../primitive';
 import { OperationInstance } from '../schema';
 
 import { Tracer } from './Tracer';
@@ -23,14 +25,23 @@ export class ConsoleTracer implements Tracer<void> {
 
   readEnd(operation: OperationInstance, result: QueryResult, cacheHit: boolean) {
     if (!this._verbose) return;
-    const { operationType, operationName } = operation.info;
-
-    const message = `read(${operationType} ${operationName})`;
+    const message = this.formatOperation('read', operation);
     if (cacheHit) {
       this._logger.debug(`${message} (cached)`, result);
     } else {
       this._logger.info(message, result);
     }
+  }
+
+  writeEnd(operation: OperationInstance, payload: JsonObject, newSnapshot: EditedSnapshot) {
+    if (!this._verbose) return;
+    this._logger.debug(this.formatOperation('write', operation), { payload, newSnapshot });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  protected formatOperation(action: string, operation: OperationInstance) {
+    const { operationType, operationName } = operation.info;
+    return `${action}(${operationType} ${operationName})`;
   }
 
 }

--- a/src/context/Tracer.ts
+++ b/src/context/Tracer.ts
@@ -1,4 +1,6 @@
 import { QueryResult } from '../operations/read';
+import { EditedSnapshot } from '../operations/SnapshotEditor';
+import { JsonObject } from '../primitive';
 import { RawOperation, OperationInstance } from '../schema';
 
 /**
@@ -23,5 +25,15 @@ export interface Tracer<TActionContext = any> {
    *
    */
   readEnd?: (operation: OperationInstance, result: QueryResult, cacheHit: boolean, context: TActionContext) => void;
+
+  /**
+   *
+   */
+  writeStart?: (rawOperation: RawOperation, payload: JsonObject) => TActionContext;
+
+  /**
+   *
+   */
+  writeEnd?: (operation: OperationInstance, payload: JsonObject, newSnapshot: EditedSnapshot, context: TActionContext) => void;
 
 }

--- a/src/context/Tracer.ts
+++ b/src/context/Tracer.ts
@@ -5,13 +5,18 @@ import { RawOperation, OperationInstance } from '../schema';
 
 export namespace Tracer {
   export interface ReadResult {
+    /** The result payload that satisfies the query. */
     result: QueryResult;
+    /** Whether this request was memoized. */
     cacheHit: boolean;
   }
 
   export interface WriteResult {
+    /** The payload to be written to the cache. */
     payload: JsonObject;
+    /** The new snapshot (and metadata) after the write is complete. */
     newSnapshot: EditedSnapshot;
+    /** Any warnings that occurred during the write. */
     warnings?: string[];
   }
 }
@@ -35,22 +40,22 @@ export interface Tracer<TActionContext = any> {
   warning?: (message: string, ...metadata: any[]) => void;
 
   /**
-   *
+   * Start of a request to read from the cache.
    */
   readStart?: (rawOperation: RawOperation) => TActionContext;
 
   /**
-   *
+   * Successful end of a request to read from the cache.
    */
   readEnd?: (operation: OperationInstance, result: Tracer.ReadResult, context: TActionContext) => void;
 
   /**
-   *
+   * Start of a request to write to the cache.
    */
   writeStart?: (rawOperation: RawOperation, payload: JsonObject) => TActionContext;
 
   /**
-   *
+   * Successful end of a request to write to the cache.
    */
   writeEnd?: (operation: OperationInstance, result: Tracer.WriteResult, context: TActionContext) => void;
 

--- a/src/context/Tracer.ts
+++ b/src/context/Tracer.ts
@@ -22,6 +22,6 @@ export interface Tracer<TActionContext = any> {
   /**
    *
    */
-  readEnd?: (operation: OperationInstance, result: QueryResult, cached: boolean, context: TActionContext) => void;
+  readEnd?: (operation: OperationInstance, result: QueryResult, cacheHit: boolean, context: TActionContext) => void;
 
 }

--- a/src/context/Tracer.ts
+++ b/src/context/Tracer.ts
@@ -1,23 +1,31 @@
+import { CacheSnapshot } from '../CacheSnapshot';
 import { QueryResult } from '../operations/read';
 import { EditedSnapshot } from '../operations/SnapshotEditor';
 import { JsonObject } from '../primitive';
-import { RawOperation, OperationInstance } from '../schema';
+import { NodeId, OperationInstance, RawOperation } from '../schema';
 
 export namespace Tracer {
-  export interface ReadResult {
+  export interface ReadInfo {
     /** The result payload that satisfies the query. */
     result: QueryResult;
     /** Whether this request was memoized. */
     cacheHit: boolean;
   }
 
-  export interface WriteResult {
+  export interface WriteInfo {
     /** The payload to be written to the cache. */
     payload: JsonObject;
     /** The new snapshot (and metadata) after the write is complete. */
     newSnapshot: EditedSnapshot;
     /** Any warnings that occurred during the write. */
     warnings?: string[];
+  }
+
+  export interface BroadcastInfo {
+    /** The snapshot being broadcast. */
+    snapshot: CacheSnapshot;
+    /** Nodes within the snapshot that were edited. */
+    editedNodeIds: Set<NodeId>;
   }
 }
 
@@ -47,7 +55,7 @@ export interface Tracer<TActionContext = any> {
   /**
    * Successful end of a request to read from the cache.
    */
-  readEnd?: (operation: OperationInstance, result: Tracer.ReadResult, context: TActionContext) => void;
+  readEnd?: (operation: OperationInstance, info: Tracer.ReadInfo, context: TActionContext) => void;
 
   /**
    * Start of a request to write to the cache.
@@ -57,6 +65,16 @@ export interface Tracer<TActionContext = any> {
   /**
    * Successful end of a request to write to the cache.
    */
-  writeEnd?: (operation: OperationInstance, result: Tracer.WriteResult, context: TActionContext) => void;
+  writeEnd?: (operation: OperationInstance, info: Tracer.WriteInfo, context: TActionContext) => void;
+
+  /**
+   * Start of a request to broadcast changes to cache observers.
+   */
+  broadcastStart?: (info: Tracer.BroadcastInfo) => TActionContext;
+
+  /**
+   * End of a request to broadcast changes to cache observers.
+   */
+  broadcastEnd?: (info: Tracer.BroadcastInfo, contet: TActionContext) => void;
 
 }

--- a/src/context/Tracer.ts
+++ b/src/context/Tracer.ts
@@ -3,11 +3,23 @@ import { EditedSnapshot } from '../operations/SnapshotEditor';
 import { JsonObject } from '../primitive';
 import { RawOperation, OperationInstance } from '../schema';
 
+export namespace Tracer {
+  export interface ReadResult {
+    result: QueryResult;
+    cacheHit: boolean;
+  }
+}
+
 /**
  * Event handlers that are called at various locations within the cache.
  *
  * Generally, this is expected to be used for instrumentation of the cache:
  * logging, performance monitoring, etc.
+ *
+ * Many actions are grouped into start/end pairs.  If a value is returned from
+ * the start handler, it will be passed to the corresponding end handler as its
+ * last (context) argument.  Handy for passing timestamps, ids, etc between
+ * paired handlers.
  */
 export interface Tracer<TActionContext = any> {
 
@@ -24,7 +36,7 @@ export interface Tracer<TActionContext = any> {
   /**
    *
    */
-  readEnd?: (operation: OperationInstance, result: QueryResult, cacheHit: boolean, context: TActionContext) => void;
+  readEnd?: (operation: OperationInstance, result: Tracer.ReadResult, context: TActionContext) => void;
 
   /**
    *

--- a/src/context/Tracer.ts
+++ b/src/context/Tracer.ts
@@ -1,0 +1,27 @@
+import { QueryResult } from '../operations/read';
+import { RawOperation, OperationInstance } from '../schema';
+
+/**
+ * Event handlers that are called at various locations within the cache.
+ *
+ * Generally, this is expected to be used for instrumentation of the cache:
+ * logging, performance monitoring, etc.
+ */
+export interface Tracer<TActionContext = any> {
+
+  /**
+   * The cache encountered a non-fatal issue.
+   */
+  warning?: (message: string, ...metadata: any[]) => void;
+
+  /**
+   *
+   */
+  readStart?: (rawOperation: RawOperation) => TActionContext;
+
+  /**
+   *
+   */
+  readEnd?: (operation: OperationInstance, result: QueryResult, cached: boolean, context: TActionContext) => void;
+
+}

--- a/src/context/Tracer.ts
+++ b/src/context/Tracer.ts
@@ -8,6 +8,12 @@ export namespace Tracer {
     result: QueryResult;
     cacheHit: boolean;
   }
+
+  export interface WriteResult {
+    payload: JsonObject;
+    newSnapshot: EditedSnapshot;
+    warnings?: string[];
+  }
 }
 
 /**
@@ -46,6 +52,6 @@ export interface Tracer<TActionContext = any> {
   /**
    *
    */
-  writeEnd?: (operation: OperationInstance, payload: JsonObject, newSnapshot: EditedSnapshot, context: TActionContext) => void;
+  writeEnd?: (operation: OperationInstance, result: Tracer.WriteResult, context: TActionContext) => void;
 
 }

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -88,7 +88,7 @@ export class SnapshotEditor {
    * Merge a GraphQL payload (query/fragment/etc) into the snapshot, rooted at
    * the node identified by `rootId`.
    */
-  mergePayload(query: RawOperation, payload: JsonObject): void {
+  mergePayload(query: RawOperation, payload: JsonObject): { warnings?: string[] } {
     const parsed = this._context.parseOperation(query);
 
     // We collect all warnings associated with this operation to avoid
@@ -115,15 +115,8 @@ export class SnapshotEditor {
     // The query should now be considered complete for future reads.
     this._writtenQueries.add(parsed);
 
-    if (warnings.length && this._context.tracer.warning) {
-      const { info } = parsed;
-      this._context.logGroup(`Warnings when writing payload for ${info.operationType} ${info.operationName}:`, () => {
-        this._context.tracer.warning!(`Payload:`, payload);
-        for (const warning of warnings) {
-          this._context.tracer.warning!(warning);
-        }
-      });
-    }
+    // Don't emit empty arrays for easy testing upstream.
+    return warnings.length ? { warnings } : {};
   }
 
   /**

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -115,12 +115,12 @@ export class SnapshotEditor {
     // The query should now be considered complete for future reads.
     this._writtenQueries.add(parsed);
 
-    if (warnings.length) {
+    if (warnings.length && this._context.tracer.warning) {
       const { info } = parsed;
       this._context.logGroup(`Warnings when writing payload for ${info.operationType} ${info.operationName}:`, () => {
-        this._context.warn(`Payload:`, payload);
+        this._context.tracer.warning!(`Payload:`, payload);
         for (const warning of warnings) {
-          this._context.warn(warning);
+          this._context.tracer.warning!(warning);
         }
       });
     }

--- a/src/operations/extract.ts
+++ b/src/operations/extract.ts
@@ -46,7 +46,7 @@ export function extract(graphSnapshot: GraphSnapshot, cacheContext: CacheContext
     const extractedData = extractSerializableData(graphSnapshot, nodeSnapshot);
     if (extractedData !== undefined) {
       if (!Serializable.isSerializable(extractedData, /* allowUndefined */ true)) {
-        cacheContext.error(`Data at entityID ${id} is unserializable`);
+        cacheContext.warn(`Data at entityID ${id} is unserializable`);
       }
       serializedEntity.data = extractedData;
     }

--- a/src/operations/extract.ts
+++ b/src/operations/extract.ts
@@ -45,8 +45,8 @@ export function extract(graphSnapshot: GraphSnapshot, cacheContext: CacheContext
     // Extract data value
     const extractedData = extractSerializableData(graphSnapshot, nodeSnapshot);
     if (extractedData !== undefined) {
-      if (!Serializable.isSerializable(extractedData, /* allowUndefined */ true)) {
-        cacheContext.warn(`Data at entityID ${id} is unserializable`);
+      if (cacheContext.tracer.warning && !Serializable.isSerializable(extractedData, /* allowUndefined */ true)) {
+        cacheContext.tracer.warning(`Data at entityID ${id} is unserializable`);
       }
       serializedEntity.data = extractedData;
     }

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -24,12 +24,19 @@ export interface QueryResultWithNodeIds extends QueryResult {
 /**
  * Get you some data.
  */
-export function read(context: CacheContext, query: RawOperation, snapshot: GraphSnapshot): QueryResult;
-export function read(context: CacheContext, query: RawOperation, snapshot: GraphSnapshot, includeNodeIds: true): QueryResultWithNodeIds;
-export function read(context: CacheContext, query: RawOperation, snapshot: GraphSnapshot, includeNodeIds?: true) {
-  const operation = context.parseOperation(query);
+export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSnapshot): QueryResult;
+export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSnapshot, includeNodeIds: true): QueryResultWithNodeIds;
+export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSnapshot, includeNodeIds?: true) {
+  let tracerContext;
+  if (context.tracer.readStart) {
+    tracerContext = context.tracer.readStart(raw)
+  }
+
+  const operation = context.parseOperation(raw);
   let queryResult = snapshot.readCache.get(operation) as Partial<QueryResultWithNodeIds>;
+  let cacheHit = true;
   if (!queryResult) {
+    cacheHit = false;
     const staticResult = snapshot.getNodeData(operation.rootId);
 
     let result = staticResult;
@@ -41,20 +48,20 @@ export function read(context: CacheContext, query: RawOperation, snapshot: Graph
 
     queryResult = { result, complete, nodeIds };
     snapshot.readCache.set(operation, queryResult as QueryResult);
-
-    if (context.verbose) {
-      const { info } = operation;
-      context.debug(`read(${info.operationType} ${info.operationName})`, { result, complete, nodeIds, snapshot });
-    }
   }
 
   // We can potentially ask for results without node ids first, and then follow
   // up with an ask for them.  In that case, we need to fill in the cache a bit
   // more.
   if (includeNodeIds && !queryResult.nodeIds) {
+    cacheHit = false;
     const { complete, nodeIds } = _visitSelection(operation, context, queryResult.result, includeNodeIds);
     queryResult.complete = complete;
     queryResult.nodeIds = nodeIds;
+  }
+
+  if (context.tracer.readEnd) {
+    context.tracer.readEnd(operation, queryResult as QueryResult, cacheHit, tracerContext);
   }
 
   return queryResult;

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -61,7 +61,8 @@ export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSn
   }
 
   if (context.tracer.readEnd) {
-    context.tracer.readEnd(operation, queryResult as QueryResult, cacheHit, tracerContext);
+    const result = { result: queryResult as QueryResult, cacheHit };
+    context.tracer.readEnd(operation, result, tracerContext);
   }
 
   return queryResult;

--- a/src/operations/write.ts
+++ b/src/operations/write.ts
@@ -21,12 +21,12 @@ export function write(context: CacheContext, snapshot: GraphSnapshot, raw: RawOp
   // convenient to follow the builder function instead - it'd end up passing
   // around a context object anyway.
   const editor = new SnapshotEditor(context, snapshot);
-  editor.mergePayload(raw, payload);
-  const result = editor.commit();
+  const { warnings } = editor.mergePayload(raw, payload);
+  const newSnapshot = editor.commit();
 
   if (context.tracer.writeEnd) {
-    context.tracer.writeEnd(context.parseOperation(raw), payload, result, tracerContext);
+    context.tracer.writeEnd(context.parseOperation(raw), { payload, newSnapshot, warnings }, tracerContext);
   }
 
-  return result;
+  return newSnapshot;
 }

--- a/src/operations/write.ts
+++ b/src/operations/write.ts
@@ -11,17 +11,21 @@ import { EditedSnapshot, SnapshotEditor } from './SnapshotEditor';
  * Performs the minimal set of edits to generate new immutable versions of each
  * node, while preserving immutability of the parent snapshot.
  */
-export function write(context: CacheContext, snapshot: GraphSnapshot, operation: RawOperation, payload: JsonObject): EditedSnapshot {
+export function write(context: CacheContext, snapshot: GraphSnapshot, raw: RawOperation, payload: JsonObject): EditedSnapshot {
+  let tracerContext;
+  if (context.tracer.writeStart) {
+    tracerContext = context.tracer.writeStart(raw, payload);
+  }
+
   // We _could_ go purely functional with the editor, but it's honestly pretty
   // convenient to follow the builder function instead - it'd end up passing
   // around a context object anyway.
   const editor = new SnapshotEditor(context, snapshot);
-  editor.mergePayload(operation, payload);
+  editor.mergePayload(raw, payload);
   const result = editor.commit();
 
-  if (context.verbose) {
-    const { info } = context.parseOperation(operation);
-    context.debug(`write(${info.operationType} ${info.operationName})`, { payload, result });
+  if (context.tracer.writeEnd) {
+    context.tracer.writeEnd(context.parseOperation(raw), payload, result, tracerContext);
   }
 
   return result;

--- a/test/helpers/context.ts
+++ b/test/helpers/context.ts
@@ -9,9 +9,6 @@ export const strictConfig: CacheContext.Configuration = {
     warn(message: string, ...args: any[]) {
       throw new Error(util.format(`warn:`, message, ...args));
     },
-    error(message: string, ...args: any[]) {
-      throw new Error(util.format(`error:`, message, ...args));
-    },
     group: jest.fn(),
     groupEnd: jest.fn(),
   },
@@ -22,7 +19,6 @@ export const silentConfig: CacheContext.Configuration = {
   logger: {
     debug: jest.fn(),
     warn: jest.fn(),
-    error: jest.fn(),
     group: jest.fn(),
     groupEnd: jest.fn(),
   },

--- a/test/helpers/context.ts
+++ b/test/helpers/context.ts
@@ -6,6 +6,7 @@ export const strictConfig: CacheContext.Configuration = {
   freeze: true,
   logger: {
     debug: jest.fn(),
+    info: jest.fn(),
     warn(message: string, ...args: any[]) {
       throw new Error(util.format(`warn:`, message, ...args));
     },
@@ -18,6 +19,7 @@ export const silentConfig: CacheContext.Configuration = {
   freeze: true,
   logger: {
     debug: jest.fn(),
+    info: jest.fn(),
     warn: jest.fn(),
     group: jest.fn(),
     groupEnd: jest.fn(),

--- a/test/unit/Cache/transactions.ts
+++ b/test/unit/Cache/transactions.ts
@@ -14,13 +14,12 @@ describe(`Cache`, () => {
       }
     }`);
 
-    let cache: Cache, debug: jest.Mock<any>, warn: jest.Mock<any>, error: jest.Mock<any>;
+    let cache: Cache, debug: jest.Mock<any>, warn: jest.Mock<any>;
     beforeEach(() => {
       debug = jest.fn();
       warn = jest.fn();
-      error = jest.fn();
       cache = new Cache({
-        logger: { debug, warn, error, group: jest.fn(), groupEnd: jest.fn() },
+        logger: { debug, warn, group: jest.fn(), groupEnd: jest.fn() },
       });
     });
 
@@ -58,8 +57,8 @@ describe(`Cache`, () => {
         throw exception;
       });
 
-      expect(error.mock.calls.length).to.eq(1);
-      expect(error.mock.calls[0]).to.include(exception);
+      expect(warn.mock.calls.length).to.eq(1);
+      expect(warn.mock.calls[0]).to.include(exception);
     });
 
   });

--- a/test/unit/Cache/transactions.ts
+++ b/test/unit/Cache/transactions.ts
@@ -14,12 +14,13 @@ describe(`Cache`, () => {
       }
     }`);
 
-    let cache: Cache, debug: jest.Mock<any>, warn: jest.Mock<any>;
+    let cache: Cache, debug: jest.Mock<any>, info: jest.Mock<any>, warn: jest.Mock<any>;
     beforeEach(() => {
       debug = jest.fn();
+      info = jest.fn();
       warn = jest.fn();
       cache = new Cache({
-        logger: { debug, warn, group: jest.fn(), groupEnd: jest.fn() },
+        logger: { debug, info, warn, group: jest.fn(), groupEnd: jest.fn() },
       });
     });
 

--- a/test/unit/context/CacheContext/onChangeWithError.ts
+++ b/test/unit/context/CacheContext/onChangeWithError.ts
@@ -18,7 +18,6 @@ describe(`context.CacheContext`, () => {
       logger: {
         debug: jest.fn(),
         warn: jest.fn(),
-        error: jest.fn(),
         group: jest.fn(),
         groupEnd: jest.fn(),
       },

--- a/test/unit/context/CacheContext/onChangeWithError.ts
+++ b/test/unit/context/CacheContext/onChangeWithError.ts
@@ -17,6 +17,7 @@ describe(`context.CacheContext`, () => {
     const cache = new Cache({
       logger: {
         debug: jest.fn(),
+        info: jest.fn(),
         warn: jest.fn(),
         group: jest.fn(),
         groupEnd: jest.fn(),


### PR DESCRIPTION
This allows us to instrument the cache at various points, and callers can use it for logging, performance monitoring, APM, etc.