### PR TITLE
Export ConsoleTracer as part of the public API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import { Hermes } from './apollo';
+export { Hermes } from './apollo';
 export { Cache } from './Cache';
-
-export { Hermes };
+export { ConsoleTracer } from './context/ConsoleTracer';


### PR DESCRIPTION
So that it can be consumed directly and/or extended