### PR TITLE
Fix read traversal

### DIFF
--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -125,6 +125,9 @@ export function _walkAndOverlayDynamicValues(
       // This is an alias if we have a schemaName declared.
       fieldName = node.schemaName ? node.schemaName : key;
 
+      let nextContainerId = containerId;
+      let nextPath = path;
+
       if (node.args) {
         let childId = nodeIdForParameterizedValue(containerId, [...path, fieldName], node.args);
         let childSnapshot = snapshot.getNodeSnapshot(childId);
@@ -147,8 +150,11 @@ export function _walkAndOverlayDynamicValues(
         // Still no snapshot? Ok we're done here.
         if (!childSnapshot) continue;
 
+        nextContainerId = childId;
+        nextPath = [];
         child = childSnapshot.data;
       } else {
+        nextPath = [...path, fieldName];
         child = value[fieldName];
       }
 
@@ -159,12 +165,12 @@ export function _walkAndOverlayDynamicValues(
           for (let i = child.length - 1; i >= 0; i--) {
             if (child[i] === null) continue;
             child[i] = _wrapValue(child[i], context);
-            queue.push(new OverlayWalkNode(child[i] as JsonObject, containerId, node.children, [...path, fieldName, i]));
+            queue.push(new OverlayWalkNode(child[i] as JsonObject, nextContainerId, node.children, [...nextPath, i]));
           }
 
         } else {
           child = _wrapValue(child, context);
-          queue.push(new OverlayWalkNode(child as JsonObject, containerId, node.children, [...path, fieldName]));
+          queue.push(new OverlayWalkNode(child as JsonObject, nextContainerId, node.children, nextPath));
         }
       }
 

--- a/test/unit/operations/read/parameterizedFields.ts
+++ b/test/unit/operations/read/parameterizedFields.ts
@@ -305,6 +305,38 @@ describe(`operations.read`, () => {
 
     });
 
+    describe(`directly nested reference without any simple fields on the intermediate object`, () => {
+
+      const nestedQuery = query(`
+      query nested($id: ID!) {
+        one(id: $id) {
+          # Notice, no simple fields on one
+          two(extra: true) {
+            id
+          }
+        }
+      }`, { id: 1 });
+
+      let snapshot: GraphSnapshot;
+      beforeAll(() => {
+        snapshot = write(context, empty, nestedQuery, {
+          one: {
+            two: { id: 2 },
+          },
+        }).snapshot;
+      });
+
+      it(`returns the selected values, overlaid on the underlying data`, () => {
+        const { result } = read(context, nestedQuery, snapshot);
+        expect(result).to.deep.equal({
+          one: {
+            two: { id: 2 },
+          },
+        });
+      });
+
+    });
+
     describe(`with a value of []`, () => {
 
       let snapshot: GraphSnapshot;


### PR DESCRIPTION
The test demonstrates the problem, but basically, if you have two nested, parameterized fields without any simple (non-parameterized) fields on the intermediate node, the intermediate node will be written into the snapshot with `null` for its `data`, which will short-circuit the dynamic value overlay walk.

The `nextContainerId` and `nextPath` juggling is necessary to ensure that arguments are affixed in the correct order as we build the path to deeper nodes. Without it, the next `OverlayWalkNode` would simply incorporate the `fieldName` of the parent, and its arguments would be lost.