### PR TITLE
Include parameterized fields in nodeIds when reading

### DIFF
--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -24,9 +24,8 @@ export interface QueryResultWithNodeIds extends QueryResult {
 /**
  * Get you some data.
  */
-export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSnapshot): QueryResult;
-export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSnapshot, includeNodeIds: true): QueryResultWithNodeIds;
-export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSnapshot, includeNodeIds?: true) {
+export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSnapshot, includeNodeIds?: true): QueryResultWithNodeIds;
+export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSnapshot, includeNodeIds = true) {
   let tracerContext;
   if (context.tracer.readStart) {
     tracerContext = context.tracer.readStart(raw);
@@ -40,11 +39,12 @@ export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSn
     const staticResult = snapshot.getNodeData(operation.rootId);
 
     let result = staticResult;
+    const nodeIds = includeNodeIds ? new Set<NodeId>() : undefined;
     if (!operation.isStatic) {
-      result = _walkAndOverlayDynamicValues(operation, context, snapshot, staticResult);
+      result = _walkAndOverlayDynamicValues(operation, context, snapshot, staticResult, nodeIds);
     }
 
-    const { complete, nodeIds } = _visitSelection(operation, context, result, includeNodeIds);
+    const complete = _visitSelection(operation, context, result, nodeIds);
 
     queryResult = { result, complete, nodeIds };
     snapshot.readCache.set(operation, queryResult as QueryResult);
@@ -55,7 +55,8 @@ export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSn
   // more.
   if (includeNodeIds && !queryResult.nodeIds) {
     cacheHit = false;
-    const { complete, nodeIds } = _visitSelection(operation, context, queryResult.result, includeNodeIds);
+    const nodeIds = new Set<NodeId>();
+    const complete = _visitSelection(operation, context, queryResult.result, nodeIds);
     queryResult.complete = complete;
     queryResult.nodeIds = nodeIds;
   }
@@ -90,6 +91,7 @@ export function _walkAndOverlayDynamicValues(
   context: CacheContext,
   snapshot: GraphSnapshot,
   result: JsonObject | undefined,
+  nodeIds?: Set<NodeId>,
 ): JsonObject | undefined {
   // Corner case: We stop walking once we reach a parameterized field with no
   // snapshot, but we should also preemptively stop walking if there are no
@@ -146,7 +148,7 @@ export function _walkAndOverlayDynamicValues(
 
         // Still no snapshot? Ok we're done here.
         if (!childSnapshot) continue;
-
+        if (nodeIds) nodeIds.add(childId);
         child = childSnapshot.data;
       } else {
         child = value[fieldName];
@@ -198,15 +200,11 @@ export function _visitSelection(
   query: OperationInstance,
   context: CacheContext,
   result?: JsonObject,
-  includeNodeIds?: true,
-): { complete: boolean, nodeIds?: Set<NodeId> } {
+  nodeIds?: Set<NodeId>,
+): boolean {
   let complete = true;
-  let nodeIds: Set<NodeId> | undefined;
-  if (includeNodeIds) {
-    nodeIds = new Set<NodeId>();
-    if (result !== undefined) {
-      nodeIds.add(query.rootId);
-    }
+  if (nodeIds && result !== undefined) {
+    nodeIds.add(query.rootId);
   }
 
   // TODO: Memoize per query, and propagate through cache snapshots.
@@ -216,7 +214,7 @@ export function _visitSelection(
     }
 
     // If we're not including node ids, we can stop the walk right here.
-    if (!complete) return !includeNodeIds;
+    if (!complete) return !nodeIds;
 
     if (!isObject(value)) return false;
 
@@ -237,5 +235,5 @@ export function _visitSelection(
     return false;
   });
 
-  return { complete, nodeIds };
+  return complete;
 }

--- a/test/unit/operations/read/parameterizedFields.ts
+++ b/test/unit/operations/read/parameterizedFields.ts
@@ -2,6 +2,10 @@ import { CacheContext } from '../../../../src/context';
 import { GraphSnapshot } from '../../../../src/GraphSnapshot';
 import { read, write } from '../../../../src/operations';
 import { query, strictConfig } from '../../../helpers';
+import { StaticNodeId } from '../../../../src/schema';
+import { nodeIdForParameterizedValue } from '../../../../src/operations/SnapshotEditor';
+
+const { QueryRoot: QueryRootId } = StaticNodeId;
 
 describe(`operations.read`, () => {
 
@@ -34,6 +38,15 @@ describe(`operations.read`, () => {
           user: { id: 1, name: 'Foo', extra: true },
           stuff: 123,
         });
+      });
+
+      it(`returns the nodeIds visited during reading`, () => {
+        const { nodeIds } = read(context, parameterizedQuery, snapshot, true);
+        expect(Array.from(nodeIds)).to.have.members([
+          QueryRootId,
+          nodeIdForParameterizedValue(QueryRootId, ['user'], {id: 1, withExtra: true}),
+          '1',
+        ]);
       });
 
     });
@@ -97,6 +110,18 @@ describe(`operations.read`, () => {
               ],
             },
           });
+        });
+
+        it(`returns the nodeIds visited during reading`, () => {
+          const { nodeIds } = read(context, nestedQuery, snapshot, true);
+          expect(Array.from(nodeIds)).to.have.members([
+            QueryRootId,
+            nodeIdForParameterizedValue(QueryRootId, ['one', 'two'], {id: 1}),
+            '1',
+            nodeIdForParameterizedValue('1', ['three', 'four'], {extra: true}),
+            '2',
+            nodeIdForParameterizedValue('2', ['three', 'four'], {extra: true}),
+          ]);
         });
 
       });

--- a/test/unit/operations/read/parameterizedFields.ts
+++ b/test/unit/operations/read/parameterizedFields.ts
@@ -1,9 +1,9 @@
 import { CacheContext } from '../../../../src/context';
 import { GraphSnapshot } from '../../../../src/GraphSnapshot';
 import { read, write } from '../../../../src/operations';
-import { query, strictConfig } from '../../../helpers';
-import { StaticNodeId } from '../../../../src/schema';
 import { nodeIdForParameterizedValue } from '../../../../src/operations/SnapshotEditor';
+import { StaticNodeId } from '../../../../src/schema';
+import { query, strictConfig } from '../../../helpers';
 
 const { QueryRoot: QueryRootId } = StaticNodeId;
 
@@ -44,7 +44,7 @@ describe(`operations.read`, () => {
         const { nodeIds } = read(context, parameterizedQuery, snapshot, true);
         expect(Array.from(nodeIds)).to.have.members([
           QueryRootId,
-          nodeIdForParameterizedValue(QueryRootId, ['user'], {id: 1, withExtra: true}),
+          nodeIdForParameterizedValue(QueryRootId, ['user'], { id: 1, withExtra: true }),
           '1',
         ]);
       });
@@ -116,11 +116,11 @@ describe(`operations.read`, () => {
           const { nodeIds } = read(context, nestedQuery, snapshot, true);
           expect(Array.from(nodeIds)).to.have.members([
             QueryRootId,
-            nodeIdForParameterizedValue(QueryRootId, ['one', 'two'], {id: 1}),
+            nodeIdForParameterizedValue(QueryRootId, ['one', 'two'], { id: 1 }),
             '1',
-            nodeIdForParameterizedValue('1', ['three', 'four'], {extra: true}),
+            nodeIdForParameterizedValue('1', ['three', 'four'], { extra: true }),
             '2',
-            nodeIdForParameterizedValue('2', ['three', 'four'], {extra: true}),
+            nodeIdForParameterizedValue('2', ['three', 'four'], { extra: true }),
           ]);
         });
 


### PR DESCRIPTION
In the interest of better tracking around read and write `nodeIds` (for the sake of avoiding unnecessary update broadcasts), I've fixed an omission where parameterized fields were not being included in the `nodeIds` during a read operation. These fields should be included because all parameterized fields are considered top-level nodes by Hermes.

Test included, works in our app. 