### PR TITLE
WIP: Re-enable smart updates based upon nodeIds in prior read results

### DIFF
--- a/src/operations/QueryObserver.ts
+++ b/src/operations/QueryObserver.ts
@@ -43,13 +43,13 @@ export class QueryObserver {
    * Whether there are any changed nodes that overlap with the ones we're
    * observing.
    */
-  private _hasUpdate(_changedNodeIds: Set<NodeId>): boolean { // eslint-disable-line class-methods-use-this
-    return true;
-    // TODO: Bring back per-node updates once it's stable!
-    // for (const nodeId of changedNodeIds) {
-    //   if (this._result.nodeIds.has(nodeId)) return true;
-    // }
-    // return false;
+  private _hasUpdate(_changedNodeIds: Set<NodeId>): boolean {
+    if (!this._result.nodeIds) return true;
+    if (!this._result.complete) return true;
+    for (const nodeId of _changedNodeIds) {
+      if (this._result.nodeIds.has(nodeId)) return true;
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
With the changes in #242 and #243, I've been able to re-enable the intelligent updates originally specified in `_hasUpdates`.

We need to test this thoroughly, but I'm curious if any unaddressed edge cases immediately come to mind?