### PR TITLE
walk ParsedQueryNode instead of documentNode in read operation

### DIFF
--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -89,8 +89,8 @@ export function _walkAndOverlayDynamicValues(
   query: OperationInstance,
   context: CacheContext,
   snapshot: GraphSnapshot,
-  result: JsonObject,
-): JsonObject {
+  result: JsonObject | undefined,
+): JsonObject | undefined {
   // Corner case: We stop walking once we reach a parameterized field with no
   // snapshot, but we should also preemptively stop walking if there are no
   // dynamic values to be overlaid
@@ -208,8 +208,7 @@ export function _visitSelection(
     }
   }
 
-  // TODO: Memoize per query, and propagate through cache snapshots.
-  walkOperation(query.info.document, result, (value, fields) => {
+  walkOperation(query.info.parsed, result, (value, fields) => {
     if (value === undefined) {
       complete = false;
     }
@@ -227,8 +226,7 @@ export function _visitSelection(
     }
 
     for (const field of fields) {
-      const nameNode = field.alias || field.name;
-      if (!(nameNode.value in value)) {
+      if (!(field in value)) {
         complete = false;
         break;
       }

--- a/src/util/tree.ts
+++ b/src/util/tree.ts
@@ -1,19 +1,9 @@
-import { // eslint-disable-line import/no-extraneous-dependencies
-  DocumentNode,
-  FieldNode,
-  SelectionSetNode,
-} from 'graphql';
-
+import { ParsedQueryWithVariables } from '../ParsedQueryNode';
 import { JsonObject, JsonValue, PathPart } from '../primitive';
 
-import { fragmentMapForDocument, getOperationOrDie } from './ast';
-
-/**
- *
- */
 class OperationWalkNode {
   constructor(
-    public readonly selectionSet: SelectionSetNode,
+    public readonly parsedOperation: ParsedQueryWithVariables,
     public readonly parent?: JsonValue,
   ) {}
 }
@@ -21,21 +11,20 @@ class OperationWalkNode {
 /**
  * Returning true indicates that the walk should STOP.
  */
-export type OperationVisitor = (parent: JsonValue | undefined, fields: FieldNode[]) => boolean;
+export type OperationVisitor = (parent: JsonValue | undefined, fields: string[]) => boolean;
 
 /**
- *
+ * Walk and run on ParsedQueryNode and the result.
+ * This is used to verify result of the read operation.
  */
-export function walkOperation(document: DocumentNode, result: JsonObject | undefined, visitor: OperationVisitor) {
-  const operation = getOperationOrDie(document);
-  const fragmentMap = fragmentMapForDocument(document);
+export function walkOperation(rootOperation: ParsedQueryWithVariables, result: JsonObject | undefined, visitor: OperationVisitor) {
 
   // Perform the walk as a depth-first traversal; and unlike the payload walk,
   // we don't bother tracking the path.
-  const stack = [new OperationWalkNode(operation.selectionSet, result)];
+  const stack = [new OperationWalkNode(rootOperation, result)];
 
   while (stack.length) {
-    const { selectionSet, parent } = stack.pop()!;
+    const { parsedOperation, parent } = stack.pop()!;
     // We consider null nodes to be skippable (and satisfy the walk).
     if (parent === null) continue;
 
@@ -43,34 +32,19 @@ export function walkOperation(document: DocumentNode, result: JsonObject | undef
     if (Array.isArray(parent)) {
       // Push in reverse purely for ergonomics: they'll be pulled off in order.
       for (let i = parent.length - 1; i >= 0; i--) {
-        stack.push(new OperationWalkNode(selectionSet, parent[i]));
+        stack.push(new OperationWalkNode(parsedOperation, parent[i]));
       }
       continue;
     }
 
-    const fields: FieldNode[] = [];
+    const fields: string[] = [];
     // TODO: Directives?
-    for (const selection of selectionSet.selections) {
-      // A simple field.
-      if (selection.kind === 'Field') {
-        fields.push(selection);
-        if (selection.selectionSet) {
-          const nameNode = selection.alias || selection.name;
-          const child = get(parent, nameNode.value);
-          stack.push(new OperationWalkNode(selection.selectionSet, child));
-        }
-
-      // Fragments are applied to the current value.
-      } else if (selection.kind === 'FragmentSpread') {
-        const fragment = fragmentMap[selection.name.value];
-        if (!fragment) {
-          throw new Error(`Expected fragment ${selection.name.value} to be defined`);
-        }
-        stack.push(new OperationWalkNode(fragment.selectionSet, parent));
-
-      // TODO: Inline fragments.
-      } else {
-        throw new Error(`Unsupported GraphQL AST Node ${selection.kind}`);
+    for (const fieldName in parsedOperation) {
+      const child = get(parent, fieldName);
+      fields.push(fieldName);
+      const nextParsedQuery = parsedOperation[fieldName].children;
+      if (nextParsedQuery) {
+        stack.push(new OperationWalkNode(nextParsedQuery, child));
       }
     }
 

--- a/src/util/tree.ts
+++ b/src/util/tree.ts
@@ -40,11 +40,10 @@ export function walkOperation(rootOperation: ParsedQueryWithVariables, result: J
     const fields: string[] = [];
     // TODO: Directives?
     for (const fieldName in parsedOperation) {
-      const child = get(parent, fieldName);
       fields.push(fieldName);
       const nextParsedQuery = parsedOperation[fieldName].children;
       if (nextParsedQuery) {
-        stack.push(new OperationWalkNode(nextParsedQuery, child));
+        stack.push(new OperationWalkNode(nextParsedQuery, get(parent, fieldName)));
       }
     }
 


### PR DESCRIPTION
This PR  is trying to make thing more consistent between read/write operation. We usually walk  ParsedQueryNode when doing operation except when we verify the read result. 