### PR TITLE
Fixed import & client initialization docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ import { ApolloClient } from 'apollo-client';
 import { Hermes } from 'apollo-cache-hermes';
 
 const client = new ApolloClient({
-  initialCache: new Hermes({ … }),
+  cache: new Hermes({ … }),
   // …
 });
 ```


### PR DESCRIPTION
Came across some bugs as I was working on testing for `apollo-cache-persist`. Sorry prettier messed up the diff, the two main things I fixed were:
- fixing the import statement for lodashGet
- fixing the readme for Apollo Client initialization