### PR TITLE
Specific error being thrown for partial read 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-cache-hermes",
-  "version": "0.4.1-alpha",
+  "version": "0.4.0-alpha",
   "description": "A cache implementation for Apollo Client, tuned for performance",
   "license": "Apache-2.0",
   "repository": "convoyinc/apollo-cache-hermes",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-cache-hermes",
-  "version": "0.4.0-alpha",
+  "version": "0.4.1-alpha",
   "description": "A cache implementation for Apollo Client, tuned for performance",
   "license": "Apache-2.0",
   "repository": "convoyinc/apollo-cache-hermes",

--- a/src/apollo/Queryable.ts
+++ b/src/apollo/Queryable.ts
@@ -1,6 +1,7 @@
 import { Cache, DataProxy } from 'apollo-cache';
 import { DocumentNode } from 'graphql'; // eslint-disable-line import/no-extraneous-dependencies
 
+import { UnsatisfiedCacheError } from '../errors';
 import { JsonObject } from '../primitive';
 import { Queryable } from '../Queryable';
 
@@ -18,7 +19,7 @@ export abstract class ApolloQueryable implements DataProxy {
     const { result, complete } = this._queryable.read(rawOperation, options.optimistic);
     if (options.returnPartialData === false && !complete) {
       // TODO: Include more detail with this error.
-      throw new Error(`diffQuery not satisfied by the cache.`);
+      throw new UnsatisfiedCacheError(`diffQuery not satisfied by the cache.`);
     }
 
     return { result, complete };
@@ -29,7 +30,7 @@ export abstract class ApolloQueryable implements DataProxy {
     const { result, complete } = this._queryable.read(rawOperation, options.optimistic);
     if (!complete) {
       // TODO: Include more detail with this error.
-      throw new Error(`read not satisfied by the cache.`);
+      throw new UnsatisfiedCacheError(`read not satisfied by the cache.`);
     }
 
     return result;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -28,11 +28,7 @@ export class QueryError extends CacheError {
  * An error with a read query - generally occurs when data in cache is partial
  * or missing.
  */
-export class UnsatisfiedCacheError extends CacheError {
-  constructor(message: string) {
-    super(message);
-  }
-}
+export class UnsatisfiedCacheError extends CacheError {}
 
 /**
  * An error thrown when multiple fields within a query disagree about what they

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -25,6 +25,16 @@ export class QueryError extends CacheError {
 }
 
 /**
+ * An error with a read query - generally occurs when data in cache is partial
+ * or missing.
+ */
+export class UnsatisfiedCacheError extends CacheError {
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+/**
  * An error thrown when multiple fields within a query disagree about what they
  * are selecting.
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './errors';
 export { Hermes } from './apollo';
 export { Cache } from './Cache';
 export { ConsoleTracer } from './context/ConsoleTracer';


### PR DESCRIPTION
Apollo cache hermes throws and error with message `read not satisfied by the cache.` upon incomplete read. As a consumer I want to identify this error as a specific error instance and ignore them. The best way to do this is check error instance of. So this change throws a new `UnsatisfiedCacheError` and exposes it as well as other errors so I can sanity check them on my app.