### PR TITLE
Freeze snapshot values, but not the read cache

### DIFF
--- a/src/GraphSnapshot.ts
+++ b/src/GraphSnapshot.ts
@@ -1,3 +1,5 @@
+import deepFreeze = require('deep-freeze-strict');
+
 import { NodeSnapshot } from './nodes';
 import { QueryResult, QueryResultWithNodeIds } from './operations/read';
 import { NodeId, OperationInstance } from './schema';
@@ -55,6 +57,15 @@ export class GraphSnapshot {
    */
   allNodeIds(): NodeId[] {
     return Object.keys(this._values);
+  }
+
+  /**
+   * Freezes the snapshot (generally for development mode)
+   *
+   * @internal
+   */
+  freeze(): void {
+    deepFreeze(this._values);
   }
 
 }

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -1,5 +1,4 @@
 import { isEqual } from 'apollo-utilities';
-import deepFreeze = require('deep-freeze-strict');
 
 import { CacheContext } from '../context';
 import { InvalidPayloadError, OperationError } from '../errors';
@@ -442,7 +441,7 @@ export class SnapshotEditor {
 
     const snapshot = this._buildNewSnapshot();
     if (this._context.freezeSnapshots) {
-      deepFreeze(snapshot);
+      snapshot.freeze();
     }
 
     return {


### PR DESCRIPTION
This was preventing us from benefiting from read caching in development mode.  Also errors