### PR TITLE
Fix optimistic transactions

### DIFF
--- a/src/CacheTransaction.ts
+++ b/src/CacheTransaction.ts
@@ -201,7 +201,7 @@ export class CacheTransaction implements Queryable {
   private _writeOptimistic(query: RawOperation, payload: JsonObject) {
     this._deltas.push({ query, payload });
 
-    const { snapshot: optimistic, editedNodeIds, writtenQueries } = write(this._context, this._snapshot.baseline, query, payload);
+    const { snapshot: optimistic, editedNodeIds, writtenQueries } = write(this._context, this._snapshot.optimistic, query, payload);
     addToSet(this._writtenQueries, writtenQueries);
     addToSet(this._editedNodeIds, editedNodeIds);
 

--- a/test/unit/Cache/transactions.ts
+++ b/test/unit/Cache/transactions.ts
@@ -75,5 +75,35 @@ describe(`Cache`, () => {
       });
     });
 
+    it(`read multiple optimistic transactions`, () => {
+      cache.transaction(
+        /** changeIdOrCallback */'123',
+        (transaction) => {
+          transaction.write(simpleQuery, { foo: { bar: 1, baz: 'hello' } });
+        }
+      );
+
+      const otherQuery = query(`{
+        fizz {
+          buzz
+        }
+      }`);
+
+      cache.transaction(
+        /** changeIdOrCallback */'456',
+        (transaction) => {
+          transaction.write(otherQuery, { fizz: { buzz: 'boom' } });
+        }
+      );
+
+      expect(cache.read(simpleQuery, /** optimistic */ true).result).to.deep.include({
+        foo: { bar: 1, baz: 'hello' },
+      });
+
+      expect(cache.read(otherQuery, /** optimistic */ true).result).to.deep.include({
+        fizz: { buzz: 'boom' },
+      });
+    });
+
   });
 });


### PR DESCRIPTION
Prior to this change, if you had multiple optimistic transactions, you'd only see the latest one reflected in the optimistic snapshot. This one-line change fixes the issue and includes a test.