### PR TITLE
WIP: Add support for `@include` and `@skip` directives

### DIFF
--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -162,6 +162,8 @@ export class SnapshotEditor {
     const payloadId = this._context.entityIdForValue(payload);
     const previousId = this._context.entityIdForValue(previousValue);
 
+    // TODO(jamesreggio): Does `excluded` need to evaluated before this?
+
     // Is this an identity change?
     if (payloadId !== previousId) {
       // It is invalid to transition from a *value* with an id to one without.
@@ -215,6 +217,10 @@ export class SnapshotEditor {
       let fieldValue = deepGet(payload, [payloadName]) as JsonValue | undefined;
       // Don't trust our inputs.  Ensure that missing values are null.
       if (fieldValue === undefined) {
+        if (node.excluded) {
+          continue;
+        }
+
         fieldValue = null;
 
         // And if it was explicitly undefined, that likely indicates a malformed

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -212,15 +212,16 @@ export class SnapshotEditor {
     // Finally, we can walk into individual values.
     for (const payloadName in parsed) {
       const node = parsed[payloadName];
+
+      if (node.excluded) {
+        continue;
+      }
+
       // Having a schemaName on the node implies that payloadName is an alias.
       const schemaName = node.schemaName ? node.schemaName : payloadName;
       let fieldValue = deepGet(payload, [payloadName]) as JsonValue | undefined;
       // Don't trust our inputs.  Ensure that missing values are null.
       if (fieldValue === undefined) {
-        if (node.excluded) {
-          continue;
-        }
-
         fieldValue = null;
 
         // And if it was explicitly undefined, that likely indicates a malformed

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -119,12 +119,13 @@ export function _walkAndOverlayDynamicValues(
 
     for (const key in parsedMap) {
       const node = parsedMap[key];
-      let child;
-      let fieldName = key;
 
       if (node.excluded) {
         continue;
       }
+
+      let child;
+      let fieldName = key;
 
       // This is an alias if we have a schemaName declared.
       fieldName = node.schemaName ? node.schemaName : key;

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -122,6 +122,10 @@ export function _walkAndOverlayDynamicValues(
       let child;
       let fieldName = key;
 
+      if (node.excluded) {
+        continue;
+      }
+
       // This is an alias if we have a schemaName declared.
       fieldName = node.schemaName ? node.schemaName : key;
 
@@ -210,7 +214,7 @@ export function _visitSelection(
   }
 
   // TODO: Memoize per query, and propagate through cache snapshots.
-  walkOperation(query.info.parsed, result, (value, fields) => {
+  walkOperation(query.parsedQuery, result, (value, fields) => {
     if (value === undefined) {
       complete = false;
     }

--- a/src/util/tree.ts
+++ b/src/util/tree.ts
@@ -39,11 +39,14 @@ export function walkOperation(rootOperation: ParsedQueryWithVariables, result: J
 
     const fields: string[] = [];
     for (const fieldName in parsedOperation) {
-      if (parsedOperation[fieldName].excluded) {
+      const node = parsedOperation[fieldName];
+
+      if (node.excluded) {
         continue;
       }
+
       fields.push(fieldName);
-      const nextParsedQuery = parsedOperation[fieldName].children;
+      const nextParsedQuery = node.children;
       if (nextParsedQuery) {
         stack.push(new OperationWalkNode(nextParsedQuery, get(parent, fieldName)));
       }

--- a/src/util/tree.ts
+++ b/src/util/tree.ts
@@ -38,8 +38,10 @@ export function walkOperation(rootOperation: ParsedQueryWithVariables, result: J
     }
 
     const fields: string[] = [];
-    // TODO: Directives?
     for (const fieldName in parsedOperation) {
+      if (parsedOperation[fieldName].excluded) {
+        continue;
+      }
       fields.push(fieldName);
       const nextParsedQuery = parsedOperation[fieldName].children;
       if (nextParsedQuery) {


### PR DESCRIPTION
This generally works for us, but I've left some concerns as `TODO` below.

My main concern is that the directives on the `SelectionNode` need to be evaluated at the time that the operation's final variables are available. Attaching the `SelectionNode` to the `ParsedQueryNode` kinda defeats the purpose of having a `ParsedQueryNode`, but it works for us for now.

Going forward, I think we'll need to pluck the relevant directives (and their variable dependencies) out of the `SelectionNode` at parse time and evaluate them similar to how we evaluate arguments. The only problem with this approach is that `shouldInclude` (in `apollo-utilities`) is a bit too coarse-grained and expects to operate on a full `SelectionNode`. Obviously, we could propose a change to `apollo-utiltiies`, if needed.

No tests or anything yet.