### PR TITLE
add cache migrate support and tests

### DIFF
--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,4 +1,5 @@
 export { extract } from './extract';
+export { migrate } from './migrate';
 export { prune } from './prune';
 export { QueryObserver } from './QueryObserver';
 export { QueryResult, read } from './read';

--- a/src/operations/migrate.ts
+++ b/src/operations/migrate.ts
@@ -1,0 +1,56 @@
+import { CacheSnapshot } from '../CacheSnapshot';
+import { EntitySnapshot } from '../nodes';
+import { JsonValue } from '../primitive';
+import { isObject, isReferenceField } from '../util';
+
+/**
+ * Function called during migration of entities to add or update a field.
+ * The new value will be whatever the function evaluates to.
+ */
+export type FieldMigration = (previous: JsonValue) => any;
+export type MigrationMap = {
+  [typeName: string]: {
+    [fieldName: string]: FieldMigration,
+  },
+};
+
+/**
+ * Return the migrated json object. Supports add and modify but not delete
+ * fields
+ */
+export function migrateEntity(snapshot: EntitySnapshot, migrationMap?: MigrationMap): EntitySnapshot {
+
+  // Only if object and if valid migrationMap is provided
+  if (!isObject(snapshot.data) || !migrationMap) return snapshot;
+
+  let typeName = snapshot.data.__typename as string | undefined;
+  if (!typeName) typeName = 'Query';
+  if (!migrationMap[typeName]) return snapshot;
+  for (const field in migrationMap[typeName]) {
+    const fieldMigration = migrationMap[typeName][field];
+    if (!fieldMigration) continue;
+    if (isReferenceField(snapshot, [field])) {
+      throw new Error(`${typeName}.${field} is a reference field. Migration is not allowed`);
+    }
+    snapshot.data[field] = fieldMigration(snapshot.data[field]);
+  }
+
+  return snapshot;
+}
+/**
+ * Migrates the CacheSnapshot. This function migrates the field values
+ * in place so use it with care. Do not use it on the Hermes' current
+ * CacheSnapshot. Doing so run the risk of violating immutability.
+ */
+export function migrate(cacheSnapshot: CacheSnapshot, migrationMap?: MigrationMap) {
+  if (migrationMap) {
+    const entities = cacheSnapshot.baseline._values;
+    for (const id in entities) {
+      const nodeSnapshot = entities[id];
+      if (nodeSnapshot instanceof EntitySnapshot) {
+        migrateEntity(nodeSnapshot, migrationMap);
+      }
+    }
+  }
+  return cacheSnapshot;
+}

--- a/src/util/references.ts
+++ b/src/util/references.ts
@@ -53,8 +53,8 @@ export function addNodeReference(
 }
 
 /**
- * Return index of { id, path } reference in references array.
- * Otherwise, return -1.
+ * Return true if { id, path } is a valid reference in the node's references
+ * array. Otherwise, return false.
  */
 export function hasNodeReference(
   snapshot: NodeSnapshot,
@@ -75,4 +75,19 @@ function getIndexOfGivenReference(references: NodeReference[], id: NodeId, path:
   return references.findIndex((reference) => {
     return reference.id === id && isEqual(reference.path, path);
   });
+}
+
+/**
+ * Return true if of 'path' points to a valid reference field
+ */
+export function isReferenceField(
+  snapshot: NodeSnapshot,
+  path: PathPart[],
+): boolean {
+  const references = snapshot['outbound'];
+  if (!references) return false;
+  const index = references.findIndex((reference) => {
+    return isEqual(reference.path, path);
+  });
+  return (index >= 0);
 }

--- a/test/unit/operations/migrate/entitiesReferencedInParameterizedValue.ts
+++ b/test/unit/operations/migrate/entitiesReferencedInParameterizedValue.ts
@@ -1,0 +1,215 @@
+import { CacheSnapshot } from '../../../../src/CacheSnapshot';
+import { CacheContext } from '../../../../src/context/CacheContext';
+import { extract, migrate } from '../../../../src/operations';
+import { nodeIdForParameterizedValue } from '../../../../src/operations/SnapshotEditor';
+import { OptimisticUpdateQueue } from '../../../../src/OptimisticUpdateQueue';
+import { JsonValue } from '../../../../src/primitive';
+import { Serializable, StaticNodeId } from '../../../../src/schema';
+import { createGraphSnapshot, strictConfig } from '../../../helpers';
+
+const { QueryRoot: QueryRootId } = StaticNodeId;
+
+function createNewCacheSnapshot(cacheContext: CacheContext) {
+  const snapshot = createGraphSnapshot(
+    {
+      one: {
+        two: [
+          {
+            three: {
+              id: 31,
+              four: { five: 1 },
+              color: 'blue',
+              __typename: 'THREE',
+            },
+          },
+          {
+            three: {
+              id: 32,
+              four: { five: 1 },
+              color: 'gold',
+              __typename: 'THREE',
+            },
+          },
+          null,
+        ],
+      },
+    },
+    `query nested($id: ID!) {
+      one {
+        two(id: $id) {
+          three {
+            id
+            four(extra: true) {
+              five
+            }
+            color
+            __typename
+          }
+        }
+      }
+    }`,
+    cacheContext,
+    { id: 1 }
+  );
+  return new CacheSnapshot(snapshot, snapshot, new OptimisticUpdateQueue());
+}
+
+describe(`operations.extract`, () => {
+  let cacheContext: CacheContext;
+  beforeAll(() => {
+    cacheContext = new CacheContext({ ...strictConfig, freeze: false });
+  });
+
+  it(`can add fields to entities referenced within parameterized value`, () => {
+    const migrated = migrate(createNewCacheSnapshot(cacheContext), { ['THREE']: {
+      size: (_previous: JsonValue) => 1024,
+    } });
+    const cacheAfter = extract(migrated.baseline, cacheContext);
+
+    const parameterizedTopContainerId = nodeIdForParameterizedValue(
+      QueryRootId,
+      ['one', 'two'],
+      { id: 1 }
+    );
+
+    const nestedParameterizedValueId0 = nodeIdForParameterizedValue(
+      '31',
+      ['four'],
+      { extra: true },
+    );
+
+    const nestedParameterizedValueId1 = nodeIdForParameterizedValue(
+      '32',
+      ['four'],
+      { extra: true },
+    );
+
+    expect(cacheAfter).to.deep.eq({
+      [QueryRootId]: {
+        type: Serializable.NodeSnapshotType.EntitySnapshot,
+        outbound: [{ id: parameterizedTopContainerId, path: ['one', 'two'] }],
+      },
+      [parameterizedTopContainerId]: {
+        type: Serializable.NodeSnapshotType.ParameterizedValueSnapshot,
+        inbound: [{ id: QueryRootId, path: ['one', 'two'] }],
+        outbound: [
+          { id: '31', path: [0, 'three'] },
+          { id: '32', path: [1, 'three'] },
+        ],
+        data: [{ three: undefined }, { three: undefined }, null],
+      },
+      '31': {
+        type: Serializable.NodeSnapshotType.EntitySnapshot,
+        inbound: [{ id: parameterizedTopContainerId, path: [0, 'three'] }],
+        outbound: [{ id: nestedParameterizedValueId0, path: ['four'] }],
+        data: {
+          id: 31,
+          color: 'blue',
+          size: 1024,
+          __typename: 'THREE',
+        },
+      },
+      [nestedParameterizedValueId0]: {
+        type: Serializable.NodeSnapshotType.ParameterizedValueSnapshot,
+        inbound: [{ id: '31', path: ['four'] }],
+        data: {
+          five: 1,
+        },
+      },
+      '32': {
+        type: Serializable.NodeSnapshotType.EntitySnapshot,
+        inbound: [{ id: parameterizedTopContainerId, path: [1, 'three'] }],
+        outbound: [{ id: nestedParameterizedValueId1, path: ['four'] }],
+        data: {
+          id: 32,
+          color: 'gold',
+          size: 1024,
+          __typename: 'THREE',
+        },
+      },
+      [nestedParameterizedValueId1]: {
+        type: Serializable.NodeSnapshotType.ParameterizedValueSnapshot,
+        inbound: [{ id: '32', path: ['four'] }],
+        data: {
+          five: 1,
+        },
+      },
+    });
+  });
+
+  it(`can modify fields to entities referenced within parameterized value`, () => {
+    const migrated = migrate(createNewCacheSnapshot(cacheContext), { ['THREE']: {
+      color: (previous: JsonValue) => `really ${previous}`,
+    } });
+    const cacheAfter = extract(migrated.baseline, cacheContext);
+
+    const parameterizedTopContainerId = nodeIdForParameterizedValue(
+      QueryRootId,
+      ['one', 'two'],
+      { id: 1 }
+    );
+
+    const nestedParameterizedValueId0 = nodeIdForParameterizedValue(
+      '31',
+      ['four'],
+      { extra: true },
+    );
+
+    const nestedParameterizedValueId1 = nodeIdForParameterizedValue(
+      '32',
+      ['four'],
+      { extra: true },
+    );
+
+    expect(cacheAfter).to.deep.eq({
+      [QueryRootId]: {
+        type: Serializable.NodeSnapshotType.EntitySnapshot,
+        outbound: [{ id: parameterizedTopContainerId, path: ['one', 'two'] }],
+      },
+      [parameterizedTopContainerId]: {
+        type: Serializable.NodeSnapshotType.ParameterizedValueSnapshot,
+        inbound: [{ id: QueryRootId, path: ['one', 'two'] }],
+        outbound: [
+          { id: '31', path: [0, 'three'] },
+          { id: '32', path: [1, 'three'] },
+        ],
+        data: [{ three: undefined }, { three: undefined }, null],
+      },
+      '31': {
+        type: Serializable.NodeSnapshotType.EntitySnapshot,
+        inbound: [{ id: parameterizedTopContainerId, path: [0, 'three'] }],
+        outbound: [{ id: nestedParameterizedValueId0, path: ['four'] }],
+        data: {
+          id: 31,
+          color: 'really blue',
+          __typename: 'THREE',
+        },
+      },
+      [nestedParameterizedValueId0]: {
+        type: Serializable.NodeSnapshotType.ParameterizedValueSnapshot,
+        inbound: [{ id: '31', path: ['four'] }],
+        data: {
+          five: 1,
+        },
+      },
+      '32': {
+        type: Serializable.NodeSnapshotType.EntitySnapshot,
+        inbound: [{ id: parameterizedTopContainerId, path: [1, 'three'] }],
+        outbound: [{ id: nestedParameterizedValueId1, path: ['four'] }],
+        data: {
+          id: 32,
+          color: 'really gold',
+          __typename: 'THREE',
+        },
+      },
+      [nestedParameterizedValueId1]: {
+        type: Serializable.NodeSnapshotType.ParameterizedValueSnapshot,
+        inbound: [{ id: '32', path: ['four'] }],
+        data: {
+          five: 1,
+        },
+      },
+    });
+  });
+
+});

--- a/test/unit/operations/migrate/entityMigrations.ts
+++ b/test/unit/operations/migrate/entityMigrations.ts
@@ -1,0 +1,160 @@
+import { CacheSnapshot } from '../../../../src/CacheSnapshot';
+import { CacheContext } from '../../../../src/context/CacheContext';
+import { extract, migrate } from '../../../../src/operations';
+import { OptimisticUpdateQueue } from '../../../../src/OptimisticUpdateQueue';
+import { JsonValue } from '../../../../src/primitive';
+import { Serializable, StaticNodeId } from '../../../../src/schema';
+import { createGraphSnapshot, strictConfig } from '../../../helpers';
+
+const { QueryRoot: QueryRootId } = StaticNodeId;
+
+function createNewCacheSnapshot(cacheContext: CacheContext) {
+  const snapshot = createGraphSnapshot(
+    {
+      foo: 123,
+      bar: 'asdf',
+      viewer: {
+        id: 'a',
+        first: 'Jonh',
+        last: 'Doe',
+        __typename: 'Viewer',
+      },
+    },
+    `{ foo bar viewer { id first last __typename } }`,
+    cacheContext
+  );
+  return new CacheSnapshot(snapshot, snapshot, new OptimisticUpdateQueue());
+}
+
+describe(`operations.migrate`, () => {
+  let cacheContext: CacheContext;
+  // let cacheSnapshot: CacheSnapshot;
+  beforeAll(() => {
+    cacheContext = new CacheContext({ ...strictConfig, freeze: false });
+  });
+
+  it(`can add fields to root`, () => {
+    const migrated = migrate(createNewCacheSnapshot(cacheContext), { ['Query']: {
+      extra: (_previous: JsonValue) => '',
+    } });
+    const cacheAfter = extract(migrated.baseline, cacheContext);
+    expect(cacheAfter).to.deep.eq({
+      [QueryRootId]: {
+        type: Serializable.NodeSnapshotType.EntitySnapshot,
+        data: {
+          foo: 123,
+          bar: 'asdf',
+          extra: '',
+          'viewer': undefined,
+        },
+        outbound: [{
+          id: 'a', path: ['viewer'],
+        }],
+      },
+      'a': {
+        type: Serializable.NodeSnapshotType.EntitySnapshot,
+        data: {
+          id: 'a',
+          first: 'Jonh',
+          last: 'Doe',
+          __typename: 'Viewer',
+        },
+        inbound: [{ id: QueryRootId, path: ['viewer'] }],
+      },
+    });
+  });
+
+  it(`can modify fields to root`, () => {
+    const migrated = migrate(createNewCacheSnapshot(cacheContext), { ['Query']: {
+      foo: (_previous: JsonValue) => 456,
+      bar: (_previous: JsonValue) => 'woohoo',
+    } });
+    const cacheAfter = extract(migrated.baseline, cacheContext);
+    expect(cacheAfter).to.deep.eq({
+      [QueryRootId]: {
+        type: Serializable.NodeSnapshotType.EntitySnapshot,
+        data: {
+          foo: 456,
+          bar: 'woohoo',
+          'viewer': undefined,
+        },
+        outbound: [{
+          id: 'a', path: ['viewer'],
+        }],
+      },
+      'a': {
+        type: Serializable.NodeSnapshotType.EntitySnapshot,
+        data: {
+          id: 'a',
+          first: 'Jonh',
+          last: 'Doe',
+          __typename: 'Viewer',
+        },
+        inbound: [{ id: QueryRootId, path: ['viewer'] }],
+      },
+    });
+  });
+
+  it(`can add fields to non-root entites`, () => {
+    const migrated = migrate(createNewCacheSnapshot(cacheContext), { ['Viewer']: {
+      suffix: (_previous: JsonValue) => 'Dr',
+    } });
+    const cacheAfter = extract(migrated.baseline, cacheContext);
+    expect(cacheAfter).to.deep.eq({
+      [QueryRootId]: {
+        type: Serializable.NodeSnapshotType.EntitySnapshot,
+        data: {
+          foo: 123,
+          bar: 'asdf',
+          'viewer': undefined,
+        },
+        outbound: [{
+          id: 'a', path: ['viewer'],
+        }],
+      },
+      'a': {
+        type: Serializable.NodeSnapshotType.EntitySnapshot,
+        data: {
+          id: 'a',
+          first: 'Jonh',
+          last: 'Doe',
+          suffix: 'Dr',
+          __typename: 'Viewer',
+        },
+        inbound: [{ id: QueryRootId, path: ['viewer'] }],
+      },
+    });
+  });
+
+  it(`can modify fields of non-root entities`, () => {
+    const migrated = migrate(createNewCacheSnapshot(cacheContext), { ['Viewer']: {
+      first: (_previous: JsonValue) => 'Adam',
+      last: (_previous: JsonValue) => 'Smith',
+    } });
+    const cacheAfter = extract(migrated.baseline, cacheContext);
+    expect(cacheAfter).to.deep.eq({
+      [QueryRootId]: {
+        type: Serializable.NodeSnapshotType.EntitySnapshot,
+        data: {
+          foo: 123,
+          bar: 'asdf',
+          'viewer': undefined,
+        },
+        outbound: [{
+          id: 'a', path: ['viewer'],
+        }],
+      },
+      'a': {
+        type: Serializable.NodeSnapshotType.EntitySnapshot,
+        data: {
+          id: 'a',
+          first: 'Adam',
+          last: 'Smith',
+          __typename: 'Viewer',
+        },
+        inbound: [{ id: QueryRootId, path: ['viewer'] }],
+      },
+    });
+  });
+
+});

--- a/test/unit/operations/migrate/exceptionCases.ts
+++ b/test/unit/operations/migrate/exceptionCases.ts
@@ -1,0 +1,43 @@
+import { CacheSnapshot } from '../../../../src/CacheSnapshot';
+import { CacheContext } from '../../../../src/context/CacheContext';
+import { extract, migrate } from '../../../../src/operations';
+import { OptimisticUpdateQueue } from '../../../../src/OptimisticUpdateQueue';
+import { JsonValue } from '../../../../src/primitive';
+import { createGraphSnapshot, strictConfig } from '../../../helpers';
+
+describe(`operations.migrate`, () => {
+  let cacheContext: CacheContext;
+  let cacheSnapshot: CacheSnapshot;
+  beforeAll(() => {
+    cacheContext = new CacheContext({ ...strictConfig, freeze: false });
+    const snapshot = createGraphSnapshot(
+      {
+        foo: 123,
+        bar: 'asdf',
+        viewer: {
+          id: 'a',
+          first: 'Jonh',
+          last: 'Doe',
+          __typename: 'Viewer',
+        },
+      },
+      `{ foo bar viewer { id first last __typename } }`,
+      cacheContext
+    );
+    cacheSnapshot = new CacheSnapshot(snapshot, snapshot, new OptimisticUpdateQueue());
+  });
+
+  it(`does nothing if no migration map is provided`, () => {
+    const migrated = migrate(cacheSnapshot);
+    const cacheAfter = extract(migrated.baseline, cacheContext);
+    expect(cacheAfter).to.be.deep.eq(extract(cacheSnapshot.baseline, cacheContext));
+  });
+
+  it(`throws if trying to migrate a reference field`, () => {
+    expect(() => {
+      migrate(cacheSnapshot, { ['Query']: {
+        viewer: (_previous: JsonValue) => '',
+      } });
+    }).to.throw(/Migration is not allowed/i);
+  });
+});


### PR DESCRIPTION
Support for a new operation, `migrate()`, which takes a `migrationMap` and migrates entities in the cache from their old shape. Useful in upgrading the persisted data following a `restore`.