### PR TITLE
Expose migration on Hermes

### DIFF
--- a/src/apollo/Hermes.ts
+++ b/src/apollo/Hermes.ts
@@ -4,7 +4,7 @@ import {
   ApolloCache,
 } from 'apollo-cache';
 
-import { Cache } from '../Cache';
+import { Cache, MigrationMap } from '../Cache';
 import { CacheSnapshot } from '../CacheSnapshot';
 import { CacheContext } from '../context';
 import { GraphSnapshot } from '../GraphSnapshot';
@@ -26,14 +26,16 @@ export class Hermes extends ApolloQueryable implements ApolloCache<GraphSnapshot
   }
 
   // TODO (yuisu): data can be typed better with update of ApolloCache API
-  restore(data: any): ApolloCache<GraphSnapshot> {
-    this._queryable.restore(data);
+  restore(data: any, migrationMap?: MigrationMap, verifyOptions?: CacheInterface.ReadOptions): ApolloCache<GraphSnapshot> {
+    const verifyQuery = verifyOptions && buildRawOperationFromQuery(verifyOptions.query, verifyOptions.variables);
+    this._queryable.restore(data, migrationMap, verifyQuery);
     return this;
   }
 
   // TODO (yuisu): return can be typed better with update of ApolloCache API
-  extract(optimistic: boolean = false): any {
-    return this._queryable.extract(optimistic);
+  extract(optimistic: boolean = false, pruneOptions?: CacheInterface.ReadOptions): any {
+    const pruneQuery = pruneOptions && buildRawOperationFromQuery(pruneOptions.query, pruneOptions.variables);
+    return this._queryable.extract(optimistic, pruneQuery);
   }
 
   reset(): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export * from './errors';
 export { Hermes } from './apollo';
-export { Cache } from './Cache';
+export { Cache, MigrationMap } from './Cache';
 export { ConsoleTracer } from './context/ConsoleTracer';
 export { selectionSetIsStatic } from './util';

--- a/src/operations/index.ts
+++ b/src/operations/index.ts
@@ -1,5 +1,5 @@
 export { extract } from './extract';
-export { migrate } from './migrate';
+export { migrate, MigrationMap } from './migrate';
 export { prune } from './prune';
 export { QueryObserver } from './QueryObserver';
 export { QueryResult, read } from './read';

--- a/test/unit/Apollo/persistenceRoundTrip.ts
+++ b/test/unit/Apollo/persistenceRoundTrip.ts
@@ -1,0 +1,143 @@
+import gql from 'graphql-tag';
+
+import { Hermes }  from '../../../src/apollo/Hermes';
+import { StaticNodeId } from '../../../src/schema';
+import { strictConfig } from '../../helpers';
+
+const baseResourcesV1 = `query baseResournces {
+  viewer {
+    id
+    name
+  }
+}`;
+
+const baseResourcesV2 = `query baseResournces {
+  viewer {
+    id
+    name
+    age
+  }
+}`;
+
+describe(`Hermes Apollo API`, () => {
+  describe(`extract/restore roundtrip`, () => {
+
+    let persisted: string;
+    beforeAll(() => {
+      const hermes = new Hermes({
+        ...strictConfig,
+        addTypename: true,
+      });
+      hermes.write({
+        query: gql(`
+          query getViewer {
+            viewer {
+              id
+              name
+            }
+            history {
+              id
+              incident
+            }
+          }
+        `),
+        result: {
+          viewer: {
+            id: 0,
+            name: 'Gouda',
+            __typename: 'Viewer',
+          },
+          history: [{
+            id: 'a',
+            incident: 'power outage',
+            __typename: 'HistoryEntry',
+          }, {
+            id: 'b',
+            incident: 'fire',
+            __typename: 'HistoryEntry',
+          }],
+        },
+        dataId: StaticNodeId.QueryRoot,
+      });
+
+      persisted = JSON.stringify(hermes.extract(false, { query: gql(baseResourcesV1), optimistic: false }));
+    });
+
+    it(`throws if schema changed but no migration map is provided on restore`, () => {
+      const hermes = new Hermes({
+        ...strictConfig,
+        addTypename: true,
+      });
+
+      expect(() => {
+        hermes.restore(JSON.parse(persisted), undefined, {
+          query: gql(baseResourcesV2),
+          optimistic: false,
+        });
+      }).to.throw();
+    });
+
+    it(`extracted data is pruned according to the prune query`, () => {
+      const hermes = new Hermes({
+        ...strictConfig,
+        addTypename: true,
+      });
+
+      expect(() => {
+        hermes.restore(JSON.parse(persisted), {
+          ['Viewer']: {
+            ['age']: _previous => '',
+          },
+        }, {
+          query: gql(baseResourcesV2),
+          optimistic: false,
+        });
+      }).to.not.throw();
+
+      expect(() => {
+        hermes.readQuery({
+          query: gql(`
+            query getViewer {
+              history {
+                id
+                incident
+              }
+            }
+          `),
+        });
+      }).to.throw(/read not satisfied by the cache/i);
+
+    });
+
+    it(`restored data is migrated and can satified query for v2 base resources`, () => {
+      const hermes = new Hermes({
+        ...strictConfig,
+        addTypename: true,
+      });
+
+      expect(() => {
+        hermes.restore(JSON.parse(persisted), {
+          ['Viewer']: {
+            ['age']: _previous => '',
+          },
+        }, {
+          query: gql(baseResourcesV2),
+          optimistic: false,
+        });
+      }).to.not.throw();
+
+      expect(hermes.readQuery({
+        query: gql(baseResourcesV2),
+      })).to.deep.eq({
+        viewer: {
+          id: 0,
+          age: '',
+          name: 'Gouda',
+          __typename: 'Viewer',
+        },
+      });
+
+    });
+
+  });
+});

--- a/test/unit/Cache/deserializeWithMigration.ts
+++ b/test/unit/Cache/deserializeWithMigration.ts
@@ -1,0 +1,131 @@
+import { Cache } from '../../../src/Cache';
+import { JsonValue } from '../../../src/primitive';
+import { query, strictConfig } from '../../helpers';
+
+describe(`Cache`, () => {
+  describe(`deserialization with migration`, () => {
+
+    const v1Query =  query(`query v1($id: ID!) {
+      one {
+        two {
+          three(id: $id, withExtra: true) {
+            id
+            name
+            extraValue
+            __typename
+          }
+        }
+      }
+    }`, { id: 0 });
+
+    const v2Query =  query(`query v1($id: ID!) {
+      one {
+        two {
+          three(id: $id, withExtra: true) {
+            id
+            name
+            extraValue
+            isNew
+            __typename
+          }
+        }
+      }
+    }`, { id: 0 });
+
+    let storedV1ExtractResult: string, expectedV2Cache: Cache;
+    beforeEach(() => {
+      const cache = new Cache(strictConfig);
+      cache.write(
+        v1Query,
+        {
+          one: {
+            two: [
+              {
+                three: {
+                  id: '30',
+                  name: 'Three0',
+                  extraValue: '30-42',
+                  __typename: 'THREE',
+                },
+              },
+              {
+                three: {
+                  id: '31',
+                  name: 'Three1',
+                  extraValue: '31-42',
+                  __typename: 'THREE',
+                },
+              },
+              null,
+            ],
+          },
+        },
+      );
+      const extractResult = cache.extract(/* optimistic */ false);
+      storedV1ExtractResult = JSON.stringify(extractResult);
+
+      // build the expected v2 cache, where 'three' gains a new 'isNew' field
+      // that defaults to 'false'
+      expectedV2Cache = new Cache(strictConfig);
+      expectedV2Cache.write(
+        v2Query,
+        {
+          one: {
+            two: [
+              {
+                three: {
+                  id: '30',
+                  name: 'Three0',
+                  extraValue: '30-42',
+                  isNew: false,
+                  __typename: 'THREE',
+                },
+              },
+              {
+                three: {
+                  id: '31',
+                  name: 'Three1',
+                  extraValue: '31-42',
+                  isNew: false,
+                  __typename: 'THREE',
+                },
+              },
+              null,
+            ],
+          },
+        },
+      );
+
+    });
+
+    it(`migrates the restored cache to v2`, () => {
+      const newCache = new Cache();
+      // set up v1 -> v2 migration map that adds the 'isNew' field to 'THREE'
+      newCache.restore(JSON.parse(storedV1ExtractResult), {
+        ['THREE']: {
+          isNew: (_previous: JsonValue) => false,
+        },
+      });
+      expect(newCache.getSnapshot()).to.deep.eq(expectedV2Cache.getSnapshot());
+    });
+
+    it(`throws if verifyQuery couldn't be satified due to missing migration map`, () => {
+      const newCache = new Cache();
+      expect(() => {
+        newCache.restore(JSON.parse(storedV1ExtractResult), undefined, v2Query);
+      }).to.throw();
+    });
+
+    it(`throws if verifyQuery couldn't be satified due to inadequate migration map`, () => {
+      const newCache = new Cache();
+      expect(() => {
+        newCache.restore(JSON.parse(storedV1ExtractResult), {
+          ['THREE']: {
+            otherStuff: (_previous: JsonValue) => false,
+          },
+        }, v2Query);
+      }).to.throw();
+    });
+
+  });
+});

--- a/test/unit/Cache/serializationWithPruning.ts
+++ b/test/unit/Cache/serializationWithPruning.ts
@@ -1,0 +1,141 @@
+import { Cache } from '../../../src/Cache';
+import { CacheSnapshot } from '../../../src/CacheSnapshot';
+import { query, strictConfig } from '../../helpers';
+
+describe(`Cache`, () => {
+  describe(`serialization with pruning`, () => {
+
+    const getAFooQuery = query(`query getAFoo($id: ID!) {
+      one {
+        two {
+          three(id: $id, withExtra: true) {
+            id name extraValue
+          }
+        }
+      }
+    }`, { id: 0 });
+
+    let originalCacheSnapshot: CacheSnapshot, cache: Cache;
+    beforeEach(() => {
+      cache = new Cache(strictConfig);
+      cache.write(
+        getAFooQuery,
+        {
+          one: {
+            two: [
+              {
+                three: {
+                  id: '30',
+                  name: 'Three0',
+                  extraValue: '30-42',
+                },
+              },
+              {
+                three: {
+                  id: '31',
+                  name: 'Three1',
+                  extraValue: '31-42',
+                },
+              },
+              null,
+            ],
+          },
+        },
+      );
+      originalCacheSnapshot = cache.getSnapshot();
+    });
+
+    it(`extracts only the sub-branch specified by the prune query`, () => {
+      // first muddy up the cache with another query
+      const muddyQuery = query(`query muddy {
+        viewer {
+          id
+          first
+          last
+          carrier {
+            id
+            hqCity
+            phoneNo
+          } 
+        }
+      }`);
+
+      cache.write(
+        muddyQuery,
+        {
+          viewer: {
+            id: 'tough007',
+            first: 'James',
+            last: 'Bond',
+            carrier: {
+              id: 'mi5',
+              hqCity: 'London',
+              phoneNo: '+44 20 7946 0820',
+            },
+          },
+        },
+      );
+
+      // extract but prune it with 'getAFooQuery'
+      const extractResult = cache.extract(/* optimistic */ false, getAFooQuery);
+      const storedExtractResult = JSON.stringify(extractResult);
+
+      const newCache = new Cache();
+      newCache.restore(JSON.parse(storedExtractResult));
+
+      // the restored cache should look as if muddyQuery never happens
+      expect(newCache.getSnapshot()).to.deep.eq(originalCacheSnapshot);
+    });
+
+    it(`can extract the cache with slightly trimmed 'three' object`, () => {
+      // set up an alternative query in which the 'three' object doesn't have
+      // the 'name' field
+      const altPruneQuery = query(`query getAFoo($id: ID!) {
+        one {
+          two {
+            three(id: $id, withExtra: true) {
+              id extraValue
+            }
+          }
+        }
+      }`, { id: 0 });
+
+      // build the expected cache
+      const expectedCache = new Cache(strictConfig);
+      expectedCache.write(
+        altPruneQuery,
+        {
+          one: {
+            two: [
+              {
+                three: {
+                  id: '30',
+                  extraValue: '30-42',
+                },
+              },
+              {
+                three: {
+                  id: '31',
+                  extraValue: '31-42',
+                },
+              },
+              null,
+            ],
+          },
+        },
+      );
+
+      // prune the original cache
+      const extractResult = cache.extract(/* optimistic */ false, altPruneQuery);
+      const storedExtractResult = JSON.stringify(extractResult);
+
+      const newCache = new Cache();
+      newCache.restore(JSON.parse(storedExtractResult));
+
+      // the restored cache should look as if it is built up from scrach with
+      // altPruneQuery
+      expect(newCache.getSnapshot()).to.deep.eq(expectedCache.getSnapshot());
+    });
+
+  });
+});


### PR DESCRIPTION
This wires up the `prune` and `migration` operation PR-ed previously to `Cache` and expose migration functionality on `Hermes`' interface. With tests, of course. 😄 