### PR TITLE
Try catch stackoverflow in isSerializable of extract

### DIFF
--- a/src/operations/extract.ts
+++ b/src/operations/extract.ts
@@ -45,8 +45,15 @@ export function extract(graphSnapshot: GraphSnapshot, cacheContext: CacheContext
     // Extract data value
     const extractedData = extractSerializableData(graphSnapshot, nodeSnapshot);
     if (extractedData !== undefined) {
-      if (cacheContext.tracer.warning && !isSerializable(extractedData, /* allowUndefined */ true)) {
-        cacheContext.tracer.warning(`Data at entityID ${id} is unserializable`);
+      if (cacheContext.tracer.warning) {
+        try {
+          if (!isSerializable(extractedData, /* allowUndefined */ true)) {
+            cacheContext.tracer.warning(`Data at entityID ${id} is unserializable`);
+          }
+        } catch (error) {
+          cacheContext.tracer.warning(`Data at entityID ${id} is unserializable because of stack overflow`);
+          cacheContext.tracer.warning(error);
+        }
       }
       serializedEntity.data = extractedData;
     }


### PR DESCRIPTION
@jamesreggio  ran into an infinite recursion during extract. This is occur inside `isSerializable` function. This is possible a result of circular reference in data. Before we are trying to instrument any fix of circular reference which is not trivia. We will catch the stack overflow error to get more context