### PR TITLE
Fix a bug that wrecks havoc upon reference bookkeeping

### DIFF
--- a/src/util/references.ts
+++ b/src/util/references.ts
@@ -21,6 +21,7 @@ export function removeNodeReference(
   if (!references) return true;
 
   const fromIndex = getIndexOfGivenReference(references, id, path);
+  if (fromIndex < 0) return false;
   references.splice(fromIndex, 1);
 
   if (!references.length) {


### PR DESCRIPTION
getIndexOfGivenReference() can return -1 if there are duplicate referenceEdits in the transaction (which can happen if the same entity is returned at different points within the payload).

[].splice(-1, 1) removes the last item from the array, which was leading to general mayhem in the wild. Hopefully this fixes some heisenbugs for everyone.

(I wasn't able to craft a test to reproduce this.)