### PR TITLE
Fix optimistic updates not getting rolled back

### DIFF
--- a/src/CacheTransaction.ts
+++ b/src/CacheTransaction.ts
@@ -79,6 +79,7 @@ export class CacheTransaction implements Queryable {
     const current = this._snapshot;
 
     const optimisticQueue = current.optimisticQueue.remove(changeId);
+    current.optimisticQueue = optimisticQueue;
     const optimistic = this._buildOptimisticSnapshot(current.baseline);
 
     this._snapshot = new CacheSnapshot(current.baseline, optimistic, optimisticQueue);

--- a/test/unit/Cache/transactions.ts
+++ b/test/unit/Cache/transactions.ts
@@ -104,4 +104,21 @@ describe(`transactions`, () => {
     });
   });
 
+  it(`rolls back optimistic transactions`, () => {
+    cache.transaction(/** changeIdOrCallback */ '123', (transaction) => {
+      transaction.write(simpleQuery, { foo: { bar: 1, baz: 'hello' } });
+    });
+
+    expect(cache.read(simpleQuery, /** optimistic */ true).result).to.deep.eq({
+      foo: { bar: 1, baz: 'hello' },
+    });
+
+    cache.transaction((transaction) => {
+      transaction.rollback('123');
+    });
+
+    expect(cache.read(simpleQuery, /** optimistic */ true).result).to.eq(
+      undefined
+    );
+  });
 });


### PR DESCRIPTION
When `transaction.rollback` was called, the resulting optimistic snapshot still included the rolled-back snapshot. The reason was `transaction._buildOptimisticSnapshot` was using the current `optimisticQueue` instead of the new one generated after removing the rolled-back update from the queue. Added failing test for the bug.