### PR TITLE
Catch an error from ReadFragment and keep going

### DIFF
--- a/src/apollo/Transaction.ts
+++ b/src/apollo/Transaction.ts
@@ -85,15 +85,20 @@ export class ApolloTransaction extends ApolloQueryable implements ApolloCache<Gr
       if (lodashIsEqual(editPath, path)) {
         const fieldArguments = getOriginalFieldArguments(outboundId);
         if (fieldArguments) {
-          const cacheResult = this.readFragment(
-            {
-              id: containerId,
-              fragment: readFragment,
-              fragmentName: readFragmentName,
-              variables: fieldArguments,
-            },
-            this._queryable.isOptimisticTransaction()
-          );
+          let cacheResult: any;
+          try {
+            cacheResult = this.readFragment(
+              {
+                id: containerId,
+                fragment: readFragment,
+                fragmentName: readFragmentName,
+                variables: fieldArguments,
+              },
+              this._queryable.isOptimisticTransaction()
+            );
+          } catch (error) {
+            continue;
+          }
           const previousData = lodasGet(cacheResult, path);
 
           if (!Array.isArray(previousData)) {


### PR DESCRIPTION
Catch error from `readFragment` (this is based on my understanding of this document
https://www.apollographql.com/docs/react/advanced/caching.html#readfragment
particularly 

> If a todo with that id does not exist in the cache you will get null back. If a todo of that id does exist in the cache, but that todo does not have the text field then an error will be thrown.

