### PR TITLE
Short-circuit repeated writes of the same entity

### DIFF
--- a/src/ParsedQueryNode.ts
+++ b/src/ParsedQueryNode.ts
@@ -87,6 +87,41 @@ export class VariableArgument {
 }
 
 /**
+ * Maintains a cache of SelectionSetNode to ParsedQuery mappings.
+ *
+ * The cache is keyed on the JSON-stringified SelectionSetNode, so equivalent
+ * SelectionSets will resolve the same ParsedQuery. This helps with avoiding
+ * duplicate writes of the same entity for a given SelectionSet.
+ */
+class SelectionSetCache {
+  private _cache: { [key: string]: ParsedQueryWithVariables | undefined } = {};
+
+  public set(key: SelectionSetNode, value: ParsedQueryWithVariables): void {
+    const hash = SelectionSetCache._hash(key);
+
+    if (hash) {
+      this._cache[hash] = value;
+    }
+  }
+
+  public get(key: SelectionSetNode): ParsedQueryWithVariables | undefined {
+    const hash = SelectionSetCache._hash(key);
+    return hash ? this._cache[hash] : undefined;
+  }
+
+  private static _hash(key: SelectionSetNode): string | undefined {
+    try {
+      // JSON.stringify is assumed to be deterministic on the VMs we target.
+      // Technically, the ordering of keys is unspecified, but in practice,
+      // JavaScriptCore and V8 will serialize in the order added.
+      return JSON.stringify(key);
+    } catch (error) {
+      return undefined;
+    }
+  }
+}
+
+/**
  * Parsed a GraphQL AST selection into a tree of ParsedQueryNode instances.
  */
 export function parseQuery(
@@ -95,7 +130,8 @@ export function parseQuery(
   selectionSet: SelectionSetNode,
 ): { parsedQuery: DeepReadonly<ParsedQueryWithVariables>, variables: Set<string> } {
   const variables = new Set<string>();
-  const parsedQuery = _buildNodeMap(variables, context, fragments, selectionSet);
+  const visitedSelectionSets = new SelectionSetCache();
+  const parsedQuery = _buildNodeMap(variables, context, fragments, visitedSelectionSets, selectionSet);
   if (!parsedQuery) {
     throw new Error(`Parsed a query, but found no fields present; it may use unsupported GraphQL features`);
   }
@@ -111,17 +147,21 @@ function _buildNodeMap(
   variables: Set<string>,
   context: CacheContext,
   fragments: FragmentMap,
+  visitedSelectionSets: SelectionSetCache,
   selectionSet?: SelectionSetNode,
   path: string[] = [],
 ): ParsedQueryWithVariables | undefined {
   if (!selectionSet) return undefined;
+
+  const cachedQueryNode = visitedSelectionSets.get(selectionSet);
+  if (cachedQueryNode) return cachedQueryNode;
 
   const nodeMap = Object.create(null);
   for (const selection of selectionSet.selections) {
     if (selection.kind === 'Field') {
       // The name of the field (as defined by the query).
       const name = selection.alias ? selection.alias.value : selection.name.value;
-      const children = _buildNodeMap(variables, context, fragments, selection.selectionSet, [...path, name]);
+      const children = _buildNodeMap(variables, context, fragments, visitedSelectionSets, selection.selectionSet, [...path, name]);
 
       let args, schemaName;
       // fields marked as @static are treated as if they are a static field in
@@ -143,7 +183,7 @@ function _buildNodeMap(
         throw new Error(`Expected fragment ${selection.name.value} to be defined`);
       }
 
-      const fragmentMap = _buildNodeMap(variables, context, fragments, fragment.selectionSet, path);
+      const fragmentMap = _buildNodeMap(variables, context, fragments, visitedSelectionSets, fragment.selectionSet, path);
       if (fragmentMap) {
         for (const name in fragmentMap) {
           nodeMap[name] = _mergeNodes([...path, name], fragmentMap[name], nodeMap[name]);
@@ -157,7 +197,9 @@ function _buildNodeMap(
     _collectDirectiveVariables(variables, selection);
   }
 
-  return Object.keys(nodeMap).length ? nodeMap : undefined;
+  const queryNode = Object.keys(nodeMap).length ? nodeMap : undefined;
+  visitedSelectionSets.set(selectionSet, queryNode);
+  return queryNode;
 }
 
 /**

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -46,6 +46,8 @@ interface ReferenceEdit {
 // https://github.com/nzakas/eslint-plugin-typescript/issues/69
 type NodeSnapshotMap = { [Key in NodeId]?: NodeSnapshot };
 
+type VisitedSubgraphsMap = { [Key in NodeId]: Set<ParsedQuery> };
+
 /**
  * Builds a set of changes to apply on top of an existing `GraphSnapshot`.
  *
@@ -99,7 +101,16 @@ export class SnapshotEditor {
     // once all new nodes have been built (and we can guarantee that we're
     // referencing the correct version).
     const referenceEdits: ReferenceEdit[] = [];
-    this._mergeSubgraph(referenceEdits, warnings, parsed.rootId, [] /* prefixPath */, [] /* path */, parsed.parsedQuery, payload);
+    this._mergeSubgraph(
+      {} /* visitedSubgraphs */,
+      referenceEdits,
+      warnings,
+      parsed.rootId,
+      [] /* prefixPath */,
+      [] /* path */,
+      parsed.parsedQuery,
+      payload,
+    );
 
     // Now that we have new versions of every edited node, we can point all the
     // edited references to the correct nodes.
@@ -123,6 +134,7 @@ export class SnapshotEditor {
    * operation.
    */
   private _mergeSubgraph(
+    visitedSubgraphs: VisitedSubgraphsMap,
     referenceEdits: ReferenceEdit[],
     warnings: string[],
     containerId: NodeId,
@@ -155,7 +167,7 @@ export class SnapshotEditor {
         throw new InvalidPayloadError(`Unsupported transition from a list to a non-list value`, prefixPath, containerId, path, payload);
       }
 
-      this._mergeArraySubgraph(referenceEdits, warnings, containerId, prefixPath, path, parsed, payload, previousValue);
+      this._mergeArraySubgraph(visitedSubgraphs, referenceEdits, warnings, containerId, prefixPath, path, parsed, payload, previousValue);
       return;
     }
 
@@ -198,6 +210,19 @@ export class SnapshotEditor {
         this._setValue(containerId, path, null, true);
       }
       return;
+    }
+
+    // Return early if we've already written payloadId with the given query.
+    if (payloadId) {
+      if (!visitedSubgraphs[payloadId]) {
+        visitedSubgraphs[payloadId] = new Set<ParsedQuery>();
+      }
+
+      if (visitedSubgraphs[payloadId].has(parsed)) {
+        return;
+      }
+
+      visitedSubgraphs[payloadId].add(parsed);
     }
 
     // If we've entered a new node; it becomes our container.
@@ -292,7 +317,16 @@ export class SnapshotEditor {
       // directly written via _setValue.  This allows us to perform minimal
       // edits to the graph.
       if (node.children) {
-        this._mergeSubgraph(referenceEdits, warnings, containerIdForField, fieldPrefixPath, fieldPath, node.children, fieldValue);
+        this._mergeSubgraph(
+          visitedSubgraphs,
+          referenceEdits,
+          warnings,
+          containerIdForField,
+          fieldPrefixPath,
+          fieldPath,
+          node.children,
+          fieldValue,
+        );
 
       // We've hit a leaf field.
       //
@@ -315,6 +349,7 @@ export class SnapshotEditor {
    * Merge an array from the payload (or previous cache data).
    */
   private _mergeArraySubgraph(
+    visitedSubgraphs: VisitedSubgraphsMap,
     referenceEdits: ReferenceEdit[],
     warnings: string[],
     containerId: NodeId,
@@ -366,7 +401,7 @@ export class SnapshotEditor {
         }
       }
 
-      this._mergeSubgraph(referenceEdits, warnings, containerId, prefixPath, [...path, i], parsed, childPayload);
+      this._mergeSubgraph(visitedSubgraphs, referenceEdits, warnings, containerId, prefixPath, [...path, i], parsed, childPayload);
     }
   }
 


### PR DESCRIPTION
This commit adds a SelectionSetCache that hashes each SelectionSet and returns a shared ParsedQueryNode for identical queries.

The resulting referential equality of ParsedQueryNodes allows us to avoid writing an entity with the same ID and query selection to the store multiple times during a write transaction, which can be quite beneficial for deeply-nested query responses (which often contain a lot of duplication).

In our app's 'notifications' query (which is complex and has many nested objects, and averages 400kb uncompressed), this change dropped the write time from a typical range of 400-650ms to between 30-40ms.

As with most my PRs, this is lacking tests, though it does not regress any existing tests.
