### PR TITLE
Add readCache carryforward

### DIFF
--- a/src/CacheTransaction.ts
+++ b/src/CacheTransaction.ts
@@ -82,6 +82,11 @@ export class CacheTransaction implements Queryable {
     current.optimisticQueue = optimisticQueue;
     const optimistic = this._buildOptimisticSnapshot(current.baseline);
 
+    // Invalidate all IDs from the soon-to-be previous optimistic snapshot,
+    // since we don't know which IDs were changed by the one we're rolling back.
+    const allIds = new Set(current.optimistic.allNodeIds());
+    addToSet(this._editedNodeIds, allIds);
+
     this._snapshot = new CacheSnapshot(current.baseline, optimistic, optimisticQueue);
   }
 

--- a/test/unit/Apollo/writeFragment/writeThenRead.ts
+++ b/test/unit/Apollo/writeFragment/writeThenRead.ts
@@ -20,9 +20,15 @@ describe(`writeFragment and then readFragment`, () => {
       complete
       date
     }
+    fragment viewerPlusShipment on Viewer {
+      ...viewer
+      shipment {
+        ...shipment
+      }
+    }
   `);
 
-  beforeAll(() => {
+  beforeEach(() => {
     hermes = new Hermes(new CacheContext(strictConfig));
     hermes.restore({
       [QueryRootId]: {
@@ -71,17 +77,10 @@ describe(`writeFragment and then readFragment`, () => {
       id: '123',
       fragmentName: 'viewer',
       fragment: readWriteFragment,
-    })).to.deep.eq({
+    })).to.include({
       id: 123,
       name: 'Munster',
       __typename: 'Viewer',
-      shipment: {
-        id: 'shipment0',
-        complete: false,
-        city: 'Seattle',
-        distance: 100,
-        __typename: 'Shipment',
-      },
     });
   });
 
@@ -99,11 +98,11 @@ describe(`writeFragment and then readFragment`, () => {
 
     expect(hermes.readFragment({
       id: '123',
-      fragmentName: 'viewer',
+      fragmentName: 'viewerPlusShipment',
       fragment: readWriteFragment,
     })).to.deep.eq({
       id: 123,
-      name: 'Munster',
+      name: 'Gouda',
       __typename: 'Viewer',
       shipment: {
         id: 'shipment0',


### PR DESCRIPTION
This is another small optimization we've been using for the past 3+ months.

This carries forward cached read results during a cache transaction (i.e., during a write) if the transaction did not modify any of the `nodeIds` referenced within a cached read-result.

This logic hinged on the correctness of the `editedNodeIds` and `_result.nodeIds` sets, and these sets appear to be full-baked now, given the merger of #244 and #360.