### PR TITLE
Allow reference field to be migrated

### DIFF
--- a/src/operations/migrate.ts
+++ b/src/operations/migrate.ts
@@ -7,7 +7,6 @@ import { JsonObject, JsonValue, PathPart } from '../primitive';
 import { NodeId } from '../schema';
 import {
   isObject,
-  isReferenceField,
   addNodeReference,
 } from '../util';
 
@@ -64,12 +63,6 @@ function migrateEntity(
     for (const field in entityMigrations[typeName]) {
       const fieldMigration = entityMigrations[typeName][field];
       if (!fieldMigration) continue;
-      // References work in very specific way in Hermes. If client tries
-      // to migrate them at will, bad things happnen. Let's not let them shoot
-      // themselves
-      if (isReferenceField(snapshot, [field])) {
-        throw new Error(`${typeName}.${field} is a reference field. Migration is not allowed`);
-      }
       snapshot.data[field] = fieldMigration(snapshot.data[field]);
     }
   }

--- a/test/unit/operations/migrate/exceptionCases.ts
+++ b/test/unit/operations/migrate/exceptionCases.ts
@@ -33,15 +33,4 @@ describe(`operations.migrate`, () => {
     expect(cacheAfter).to.be.deep.eq(extract(cacheSnapshot.baseline, cacheContext));
   });
 
-  it(`throws if trying to migrate a reference field`, () => {
-    expect(() => {
-      migrate(cacheSnapshot, {
-        _entities: {
-          Query: {
-            viewer: (_previous: JsonValue) => '',
-          },
-        },
-      });
-    }).to.throw(/Migration is not allowed/i);
-  });
 });

--- a/test/unit/operations/migrate/exceptionCases.ts
+++ b/test/unit/operations/migrate/exceptionCases.ts
@@ -2,7 +2,6 @@ import { CacheSnapshot } from '../../../../src/CacheSnapshot';
 import { CacheContext } from '../../../../src/context/CacheContext';
 import { extract, migrate } from '../../../../src/operations';
 import { OptimisticUpdateQueue } from '../../../../src/OptimisticUpdateQueue';
-import { JsonValue } from '../../../../src/primitive';
 import { createGraphSnapshot, strictConfig } from '../../../helpers';
 
 describe(`operations.migrate`, () => {


### PR DESCRIPTION
Removed unnecessary check preventing migration adding reference fields to existing entity.

e.g. adding
```
citation {
  id
  citationNumber
}
```
to `fullArticle` fragment.

The reference field check prevents the valid migrations like:
```
_entities: {
  Article: {
	citation: previous => previous || null
  }
}
```
from moving forward. 😢 
