### PR TITLE
[Tests] Translate some tests to Jest expect

### DIFF
--- a/test/env/base.ts
+++ b/test/env/base.ts
@@ -4,9 +4,14 @@ import chaiJestDiff from 'chai-jest-diff';
 
 // Chai
 
-// We prefer Chai's `expect` interface.
+// We are transitioning to using Jasmine for our test expects.  During the
+// transition, Jasmine and chai will be run in parallel using jestExpect for
+// Jasmine, and the default expect for chai.  Once complete, Jasmine will
+// replace the chai global.expect.
 global.jestExpect = global.expect;
+// We prefer Chai's `expect` interface.
 global.expect = chai.expect;
+
 // Give us all the info!
 chai.config.truncateThreshold = 0;
 

--- a/test/env/base.ts
+++ b/test/env/base.ts
@@ -5,6 +5,7 @@ import chaiJestDiff from 'chai-jest-diff';
 // Chai
 
 // We prefer Chai's `expect` interface.
+global.jestExpect = global.expect;
 global.expect = chai.expect;
 // Give us all the info!
 chai.config.truncateThreshold = 0;

--- a/test/unit/operations/restore/basic/arrayOfReferencesOffARoot.ts
+++ b/test/unit/operations/restore/basic/arrayOfReferencesOffARoot.ts
@@ -84,22 +84,22 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('123')).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('456')).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('123')).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('456')).toBeInstanceOf(EntitySnapshot);
     });
 
     it(`correctly restores NodeSnapshot, entity transformation on specific entity`, () => {
-      expect(restoreGraphSnapshot.getNodeData('123')).to.be.an.instanceOf(Viewer);
-      expect(restoreGraphSnapshot.getNodeData('456')).to.be.an.instanceOf(Viewer);
+      expect(restoreGraphSnapshot.getNodeData('123')).toBeInstanceOf(Viewer);
+      expect(restoreGraphSnapshot.getNodeData('456')).toBeInstanceOf(Viewer);
     });
 
     it(`correctly restores NodeSnapshot, no entity transformation on QueryRootId`, () => {
-      expect(restoreGraphSnapshot.getNodeData(QueryRootId)).to.not.be.an.instanceOf(Viewer);
+      expect(restoreGraphSnapshot.getNodeData(QueryRootId)).not.toBeInstanceOf(Viewer);
     });
 
   });

--- a/test/unit/operations/restore/basic/arrayOfReferencesOffARoot.ts
+++ b/test/unit/operations/restore/basic/arrayOfReferencesOffARoot.ts
@@ -84,22 +84,22 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('123')).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('456')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('123')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('456')).toBeInstanceOf(EntitySnapshot);
     });
 
     it(`correctly restores NodeSnapshot, entity transformation on specific entity`, () => {
-      expect(restoreGraphSnapshot.getNodeData('123')).toBeInstanceOf(Viewer);
-      expect(restoreGraphSnapshot.getNodeData('456')).toBeInstanceOf(Viewer);
+      jestExpect(restoreGraphSnapshot.getNodeData('123')).toBeInstanceOf(Viewer);
+      jestExpect(restoreGraphSnapshot.getNodeData('456')).toBeInstanceOf(Viewer);
     });
 
     it(`correctly restores NodeSnapshot, no entity transformation on QueryRootId`, () => {
-      expect(restoreGraphSnapshot.getNodeData(QueryRootId)).not.toBeInstanceOf(Viewer);
+      jestExpect(restoreGraphSnapshot.getNodeData(QueryRootId)).not.toBeInstanceOf(Viewer);
     });
 
   });

--- a/test/unit/operations/restore/basic/arrayOfValuesOffARoot.ts
+++ b/test/unit/operations/restore/basic/arrayOfValuesOffARoot.ts
@@ -49,11 +49,11 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/basic/arrayOfValuesOffARoot.ts
+++ b/test/unit/operations/restore/basic/arrayOfValuesOffARoot.ts
@@ -49,11 +49,11 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/basic/emptyObjectLeafValueOffARoot.ts
+++ b/test/unit/operations/restore/basic/emptyObjectLeafValueOffARoot.ts
@@ -27,11 +27,11 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/basic/emptyObjectLeafValueOffARoot.ts
+++ b/test/unit/operations/restore/basic/emptyObjectLeafValueOffARoot.ts
@@ -27,11 +27,11 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/basic/falsyValues.ts
+++ b/test/unit/operations/restore/basic/falsyValues.ts
@@ -27,11 +27,11 @@ describe(`operations.restore`, () => {
         `{ null, false, zero, string }`,
         cacheContext
       );
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/basic/falsyValues.ts
+++ b/test/unit/operations/restore/basic/falsyValues.ts
@@ -27,11 +27,11 @@ describe(`operations.restore`, () => {
         `{ null, false, zero, string }`,
         cacheContext
       );
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/basic/invalidNodeSnapshot.ts
+++ b/test/unit/operations/restore/basic/invalidNodeSnapshot.ts
@@ -23,7 +23,7 @@ describe(`operations.restore`, () => {
             },
           },
         }, cacheContext);
-      }).to.throw(/Invalid Serializable.NodeSnapshotType/i);
+      }).toThrow(/Invalid Serializable.NodeSnapshotType/i);
     });
 
   });

--- a/test/unit/operations/restore/basic/invalidNodeSnapshot.ts
+++ b/test/unit/operations/restore/basic/invalidNodeSnapshot.ts
@@ -8,7 +8,7 @@ describe(`operations.restore`, () => {
   describe(`invalid NodeSnapshot type`, () => {
 
     it(`throws error when restore invalid NodeSnapshot type`, () => {
-      expect(() => {
+      jestExpect(() => {
         const cacheContext = createStrictCacheContext();
         restore({
           [QueryRootId]: {

--- a/test/unit/operations/restore/basic/multidimensionalReferencesArray.ts
+++ b/test/unit/operations/restore/basic/multidimensionalReferencesArray.ts
@@ -81,11 +81,11 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/basic/multidimensionalReferencesArray.ts
+++ b/test/unit/operations/restore/basic/multidimensionalReferencesArray.ts
@@ -81,11 +81,11 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/basic/multidimensionalValuesArray.ts
+++ b/test/unit/operations/restore/basic/multidimensionalValuesArray.ts
@@ -53,11 +53,11 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/basic/multidimensionalValuesArray.ts
+++ b/test/unit/operations/restore/basic/multidimensionalValuesArray.ts
@@ -53,11 +53,11 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/basic/multipleReferencesOffARoot.ts
+++ b/test/unit/operations/restore/basic/multipleReferencesOffARoot.ts
@@ -126,23 +126,23 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originaGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originaGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('123')).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('456')).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('123')).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('456')).toBeInstanceOf(EntitySnapshot);
     });
 
     it(`correctly restore NodeSnapshot, entity transformation on specific entity`, () => {
-      expect(restoreGraphSnapshot.getNodeData('123')).to.be.an.instanceOf(Bar);
-      expect(restoreGraphSnapshot.getNodeData('456')).to.be.an.instanceOf(Foo);
+      expect(restoreGraphSnapshot.getNodeData('123')).toBeInstanceOf(Bar);
+      expect(restoreGraphSnapshot.getNodeData('456')).toBeInstanceOf(Foo);
     });
 
     it(`correctly restore NodeSnapshot, no entity transformation on QueryRootId`, () => {
-      expect(restoreGraphSnapshot.getNodeData(QueryRootId)).to.not.be.an.instanceOf(Bar);
-      expect(restoreGraphSnapshot.getNodeData(QueryRootId)).to.not.be.an.instanceOf(Foo);
+      expect(restoreGraphSnapshot.getNodeData(QueryRootId)).not.toBeInstanceOf(Bar);
+      expect(restoreGraphSnapshot.getNodeData(QueryRootId)).not.toBeInstanceOf(Foo);
     });
 
   });

--- a/test/unit/operations/restore/basic/multipleReferencesOffARoot.ts
+++ b/test/unit/operations/restore/basic/multipleReferencesOffARoot.ts
@@ -126,23 +126,23 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originaGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originaGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('123')).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('456')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('123')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('456')).toBeInstanceOf(EntitySnapshot);
     });
 
     it(`correctly restore NodeSnapshot, entity transformation on specific entity`, () => {
-      expect(restoreGraphSnapshot.getNodeData('123')).toBeInstanceOf(Bar);
-      expect(restoreGraphSnapshot.getNodeData('456')).toBeInstanceOf(Foo);
+      jestExpect(restoreGraphSnapshot.getNodeData('123')).toBeInstanceOf(Bar);
+      jestExpect(restoreGraphSnapshot.getNodeData('456')).toBeInstanceOf(Foo);
     });
 
     it(`correctly restore NodeSnapshot, no entity transformation on QueryRootId`, () => {
-      expect(restoreGraphSnapshot.getNodeData(QueryRootId)).not.toBeInstanceOf(Bar);
-      expect(restoreGraphSnapshot.getNodeData(QueryRootId)).not.toBeInstanceOf(Foo);
+      jestExpect(restoreGraphSnapshot.getNodeData(QueryRootId)).not.toBeInstanceOf(Bar);
+      jestExpect(restoreGraphSnapshot.getNodeData(QueryRootId)).not.toBeInstanceOf(Foo);
     });
 
   });

--- a/test/unit/operations/restore/basic/nestedReference.ts
+++ b/test/unit/operations/restore/basic/nestedReference.ts
@@ -77,20 +77,20 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('0')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('0')).toBeInstanceOf(EntitySnapshot);
     });
 
     it(`correctly restore NodeSnapshot, entity transformation on specific entity`, () => {
-      expect(restoreGraphSnapshot.getNodeData('0')).toBeInstanceOf(Three);
+      jestExpect(restoreGraphSnapshot.getNodeData('0')).toBeInstanceOf(Three);
     });
 
     it(`correctly restore NodeSnapshot, no entity transformation on QueryRootId`, () => {
-      expect(restoreGraphSnapshot.getNodeData(QueryRootId)).not.toBeInstanceOf(Three);
+      jestExpect(restoreGraphSnapshot.getNodeData(QueryRootId)).not.toBeInstanceOf(Three);
     });
 
   });

--- a/test/unit/operations/restore/basic/nestedReference.ts
+++ b/test/unit/operations/restore/basic/nestedReference.ts
@@ -77,20 +77,20 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('0')).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('0')).toBeInstanceOf(EntitySnapshot);
     });
 
     it(`correctly restore NodeSnapshot, entity transformation on specific entity`, () => {
-      expect(restoreGraphSnapshot.getNodeData('0')).to.be.an.instanceOf(Three);
+      expect(restoreGraphSnapshot.getNodeData('0')).toBeInstanceOf(Three);
     });
 
     it(`correctly restore NodeSnapshot, no entity transformation on QueryRootId`, () => {
-      expect(restoreGraphSnapshot.getNodeData(QueryRootId)).to.not.be.an.instanceOf(Three);
+      expect(restoreGraphSnapshot.getNodeData(QueryRootId)).not.toBeInstanceOf(Three);
     });
 
   });

--- a/test/unit/operations/restore/basic/nestedReferenceWithPeerReferences.ts
+++ b/test/unit/operations/restore/basic/nestedReferenceWithPeerReferences.ts
@@ -59,13 +59,13 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('0')).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('1')).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('0')).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('1')).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/basic/nestedReferenceWithPeerReferences.ts
+++ b/test/unit/operations/restore/basic/nestedReferenceWithPeerReferences.ts
@@ -59,13 +59,13 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('0')).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('1')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('0')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('1')).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/basic/nestedReferencesInArray.ts
+++ b/test/unit/operations/restore/basic/nestedReferencesInArray.ts
@@ -87,22 +87,22 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('0')).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('1')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('0')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('1')).toBeInstanceOf(EntitySnapshot);
     });
 
     it(`correctly restore NodeSnapshot, entity transformation on specific entity`, () => {
-      expect(restoreGraphSnapshot.getNodeData('0')).toBeInstanceOf(Three);
-      expect(restoreGraphSnapshot.getNodeData('1')).toBeInstanceOf(Three);
+      jestExpect(restoreGraphSnapshot.getNodeData('0')).toBeInstanceOf(Three);
+      jestExpect(restoreGraphSnapshot.getNodeData('1')).toBeInstanceOf(Three);
     });
 
     it(`correctly restore NodeSnapshot, no entity transformation on QueryRootId`, () => {
-      expect(restoreGraphSnapshot.getNodeData(QueryRootId)).not.toBeInstanceOf(Three);
+      jestExpect(restoreGraphSnapshot.getNodeData(QueryRootId)).not.toBeInstanceOf(Three);
     });
 
   });

--- a/test/unit/operations/restore/basic/nestedReferencesInArray.ts
+++ b/test/unit/operations/restore/basic/nestedReferencesInArray.ts
@@ -87,22 +87,22 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('0')).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('1')).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('0')).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('1')).toBeInstanceOf(EntitySnapshot);
     });
 
     it(`correctly restore NodeSnapshot, entity transformation on specific entity`, () => {
-      expect(restoreGraphSnapshot.getNodeData('0')).to.be.an.instanceOf(Three);
-      expect(restoreGraphSnapshot.getNodeData('1')).to.be.an.instanceOf(Three);
+      expect(restoreGraphSnapshot.getNodeData('0')).toBeInstanceOf(Three);
+      expect(restoreGraphSnapshot.getNodeData('1')).toBeInstanceOf(Three);
     });
 
     it(`correctly restore NodeSnapshot, no entity transformation on QueryRootId`, () => {
-      expect(restoreGraphSnapshot.getNodeData(QueryRootId)).to.not.be.an.instanceOf(Three);
+      expect(restoreGraphSnapshot.getNodeData(QueryRootId)).not.toBeInstanceOf(Three);
     });
 
   });

--- a/test/unit/operations/restore/basic/nestedValueOffARoot.ts
+++ b/test/unit/operations/restore/basic/nestedValueOffARoot.ts
@@ -54,11 +54,11 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/basic/nestedValueOffARoot.ts
+++ b/test/unit/operations/restore/basic/nestedValueOffARoot.ts
@@ -54,11 +54,11 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/basic/nestedValuesInArray.ts
+++ b/test/unit/operations/restore/basic/nestedValuesInArray.ts
@@ -47,11 +47,11 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/basic/nestedValuesInArray.ts
+++ b/test/unit/operations/restore/basic/nestedValuesInArray.ts
@@ -47,11 +47,11 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/basic/simpleLeafValuesOffARoot.ts
+++ b/test/unit/operations/restore/basic/simpleLeafValuesOffARoot.ts
@@ -27,11 +27,11 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/basic/simpleLeafValuesOffARoot.ts
+++ b/test/unit/operations/restore/basic/simpleLeafValuesOffARoot.ts
@@ -27,11 +27,11 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/basic/simpleReferenceOffARoot.ts
+++ b/test/unit/operations/restore/basic/simpleReferenceOffARoot.ts
@@ -47,12 +47,12 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('123')).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('123')).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/basic/simpleReferenceOffARoot.ts
+++ b/test/unit/operations/restore/basic/simpleReferenceOffARoot.ts
@@ -47,12 +47,12 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('123')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('123')).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/cyclicReferencesGraph.ts
+++ b/test/unit/operations/restore/cyclicReferencesGraph.ts
@@ -73,13 +73,13 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('1')).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('2')).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('1')).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('2')).toBeInstanceOf(EntitySnapshot);
     });
 
     it(`restores RootQuery GraphSnapshot from JSON serialization object`, () => {
@@ -88,9 +88,9 @@ describe(`operations.restore`, () => {
 
       const fooData = restoreGraphSnapshot.getNodeData('1');
 
-      expect(rootGraphSnapshot.inbound).to.eq(undefined);
-      expect(rootGraphSnapshot.outbound).to.have.deep.members([{ id: '1', path: ['foo'] }]);
-      expect(rootData.foo).to.eq(fooData);
+      expect(rootGraphSnapshot.inbound).toBe(undefined);
+      expect(rootGraphSnapshot.outbound).toEqual([{ id: '1', path: ['foo'] }]);
+      expect(rootData.foo).toBe(fooData);
     });
 
     it(`restores id='1' GraphSnapshot from JSON serialization object`, () => {
@@ -98,14 +98,14 @@ describe(`operations.restore`, () => {
       const fooData = restoreGraphSnapshot.getNodeData('1');
       const barData = restoreGraphSnapshot.getNodeData('2');
 
-      expect(fooGraphSnapshot.inbound).to.have.deep.members([
+      expect(fooGraphSnapshot.inbound).toEqual([
         { id: QueryRootId, path: ['foo'] },
         { id: '2', path: ['fizz'] },
       ]);
-      expect(fooGraphSnapshot.outbound).to.have.deep.members([{ id: '2', path: ['bar'] }]);
-      expect(fooData.id).to.eq(1);
-      expect(fooData.name).to.eq('Foo');
-      expect(fooData.bar).to.eq(barData);
+      expect(fooGraphSnapshot.outbound).toEqual([{ id: '2', path: ['bar'] }]);
+      expect(fooData.id).toBe(1);
+      expect(fooData.name).toBe('Foo');
+      expect(fooData.bar).toBe(barData);
     });
 
     it(`restores id='2' GraphSnapshot from JSON serialization object`, () => {
@@ -113,18 +113,18 @@ describe(`operations.restore`, () => {
       const fooData = restoreGraphSnapshot.getNodeData('1');
       const barData = restoreGraphSnapshot.getNodeData('2');
 
-      expect(barGraphSnapshot.inbound).to.have.deep.members([
+      expect(barGraphSnapshot.inbound).toEqual([
         { id: '1', path: ['bar'] },
         { id: '2', path: ['buzz'] },
       ]);
-      expect(barGraphSnapshot.outbound).to.have.deep.members([
+      expect(barGraphSnapshot.outbound).toEqual([
         { id: '1', path: ['fizz'] },
         { id: '2', path: ['buzz'] },
       ]);
-      expect(barData.id).to.eq(2);
-      expect(barData.name).to.eq('Bar');
-      expect(barData.fizz).to.eq(fooData);
-      expect(barData.buzz).to.eq(barData);
+      expect(barData.id).toBe(2);
+      expect(barData.name).toBe('Bar');
+      expect(barData.fizz).toBe(fooData);
+      expect(barData.buzz).toBe(barData);
     });
 
   });

--- a/test/unit/operations/restore/cyclicReferencesGraph.ts
+++ b/test/unit/operations/restore/cyclicReferencesGraph.ts
@@ -73,13 +73,13 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('1')).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('2')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('1')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('2')).toBeInstanceOf(EntitySnapshot);
     });
 
     it(`restores RootQuery GraphSnapshot from JSON serialization object`, () => {
@@ -88,9 +88,9 @@ describe(`operations.restore`, () => {
 
       const fooData = restoreGraphSnapshot.getNodeData('1');
 
-      expect(rootGraphSnapshot.inbound).toBe(undefined);
-      expect(rootGraphSnapshot.outbound).toEqual([{ id: '1', path: ['foo'] }]);
-      expect(rootData.foo).toBe(fooData);
+      jestExpect(rootGraphSnapshot.inbound).toBe(undefined);
+      jestExpect(rootGraphSnapshot.outbound).toEqual([{ id: '1', path: ['foo'] }]);
+      jestExpect(rootData.foo).toBe(fooData);
     });
 
     it(`restores id='1' GraphSnapshot from JSON serialization object`, () => {
@@ -98,14 +98,14 @@ describe(`operations.restore`, () => {
       const fooData = restoreGraphSnapshot.getNodeData('1');
       const barData = restoreGraphSnapshot.getNodeData('2');
 
-      expect(fooGraphSnapshot.inbound).toEqual([
+      jestExpect(fooGraphSnapshot.inbound).toEqual([
         { id: QueryRootId, path: ['foo'] },
         { id: '2', path: ['fizz'] },
       ]);
-      expect(fooGraphSnapshot.outbound).toEqual([{ id: '2', path: ['bar'] }]);
-      expect(fooData.id).toBe(1);
-      expect(fooData.name).toBe('Foo');
-      expect(fooData.bar).toBe(barData);
+      jestExpect(fooGraphSnapshot.outbound).toEqual([{ id: '2', path: ['bar'] }]);
+      jestExpect(fooData.id).toBe(1);
+      jestExpect(fooData.name).toBe('Foo');
+      jestExpect(fooData.bar).toBe(barData);
     });
 
     it(`restores id='2' GraphSnapshot from JSON serialization object`, () => {
@@ -113,18 +113,18 @@ describe(`operations.restore`, () => {
       const fooData = restoreGraphSnapshot.getNodeData('1');
       const barData = restoreGraphSnapshot.getNodeData('2');
 
-      expect(barGraphSnapshot.inbound).toEqual([
+      jestExpect(barGraphSnapshot.inbound).toEqual([
         { id: '1', path: ['bar'] },
         { id: '2', path: ['buzz'] },
       ]);
-      expect(barGraphSnapshot.outbound).toEqual([
+      jestExpect(barGraphSnapshot.outbound).toEqual([
         { id: '1', path: ['fizz'] },
         { id: '2', path: ['buzz'] },
       ]);
-      expect(barData.id).toBe(2);
-      expect(barData.name).toBe('Bar');
-      expect(barData.fizz).toBe(fooData);
-      expect(barData.buzz).toBe(barData);
+      jestExpect(barData.id).toBe(2);
+      jestExpect(barData.name).toBe('Bar');
+      jestExpect(barData.fizz).toBe(fooData);
+      jestExpect(barData.buzz).toBe(barData);
     });
 
   });

--- a/test/unit/operations/restore/duplicateReferencesGraph.ts
+++ b/test/unit/operations/restore/duplicateReferencesGraph.ts
@@ -89,14 +89,14 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('1')).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('a')).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('b')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('1')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('a')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('b')).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/duplicateReferencesGraph.ts
+++ b/test/unit/operations/restore/duplicateReferencesGraph.ts
@@ -89,14 +89,14 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('1')).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('a')).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('b')).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('1')).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('a')).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('b')).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/multidimensionalReferencesArray.ts
+++ b/test/unit/operations/restore/parameterizedFields/multidimensionalReferencesArray.ts
@@ -97,11 +97,11 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/multidimensionalReferencesArray.ts
+++ b/test/unit/operations/restore/parameterizedFields/multidimensionalReferencesArray.ts
@@ -97,11 +97,11 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/nestedParameterizedReference.ts
+++ b/test/unit/operations/restore/parameterizedFields/nestedParameterizedReference.ts
@@ -68,22 +68,22 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('31')).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).to.be.an.instanceof(ParameterizedValueSnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('31')).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
     });
 
     it(`restores parameterized RootQuery NodeSnapshot JSON serialization object`, () => {
       const parameterizedContainersNode = restoreGraphSnapshot.getNodeSnapshot(parameterizedId)!;
       const entityData = restoreGraphSnapshot.getNodeData('31');
 
-      expect(parameterizedContainersNode.inbound).to.have.deep.members([{ id: QueryRootId, path: ['one', 'two', 'three'] }]);
-      expect(parameterizedContainersNode.outbound).to.have.deep.members([{ id: '31', path: [] }]);
-      expect(parameterizedContainersNode.data).to.eq(entityData);
+      expect(parameterizedContainersNode.inbound).toEqual([{ id: QueryRootId, path: ['one', 'two', 'three'] }]);
+      expect(parameterizedContainersNode.outbound).toEqual([{ id: '31', path: [] }]);
+      expect(parameterizedContainersNode.data).toBe(entityData);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/nestedParameterizedReference.ts
+++ b/test/unit/operations/restore/parameterizedFields/nestedParameterizedReference.ts
@@ -68,22 +68,22 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('31')).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('31')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
     });
 
     it(`restores parameterized RootQuery NodeSnapshot JSON serialization object`, () => {
       const parameterizedContainersNode = restoreGraphSnapshot.getNodeSnapshot(parameterizedId)!;
       const entityData = restoreGraphSnapshot.getNodeData('31');
 
-      expect(parameterizedContainersNode.inbound).toEqual([{ id: QueryRootId, path: ['one', 'two', 'three'] }]);
-      expect(parameterizedContainersNode.outbound).toEqual([{ id: '31', path: [] }]);
-      expect(parameterizedContainersNode.data).toBe(entityData);
+      jestExpect(parameterizedContainersNode.inbound).toEqual([{ id: QueryRootId, path: ['one', 'two', 'three'] }]);
+      jestExpect(parameterizedContainersNode.outbound).toEqual([{ id: '31', path: [] }]);
+      jestExpect(parameterizedContainersNode.data).toBe(entityData);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/nestedParameterizedReferenceInArray.ts
+++ b/test/unit/operations/restore/parameterizedFields/nestedParameterizedReferenceInArray.ts
@@ -107,34 +107,34 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId0)).to.be.an.instanceof(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('30')).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId1)).to.be.an.instanceof(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('31')).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId0)).toBeInstanceOf(ParameterizedValueSnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('30')).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId1)).toBeInstanceOf(ParameterizedValueSnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('31')).toBeInstanceOf(EntitySnapshot);
     });
 
     it(`restores parameterized NodeSnapshot in an array at index=0 from JSON serialization object`, () => {
       const parameterizedElement0 = restoreGraphSnapshot.getNodeSnapshot(parameterizedId0)!;
       const entityElement0 = restoreGraphSnapshot.getNodeData('30');
 
-      expect(parameterizedElement0.inbound).to.have.deep.members([{ id: QueryRootId, path: ['one', 'two', 0, 'three'] }]);
-      expect(parameterizedElement0.outbound).to.have.deep.members([{ id: '30', path: [] }]);
-      expect(parameterizedElement0.data).to.eq(entityElement0);
+      expect(parameterizedElement0.inbound).toEqual([{ id: QueryRootId, path: ['one', 'two', 0, 'three'] }]);
+      expect(parameterizedElement0.outbound).toEqual([{ id: '30', path: [] }]);
+      expect(parameterizedElement0.data).toBe(entityElement0);
     });
 
     it(`restores parameterized NodeSnapshot at index=1 from JSON serialization object`, () => {
       const parameterizedElement1 = restoreGraphSnapshot.getNodeSnapshot(parameterizedId1)!;
       const entityElement1 = restoreGraphSnapshot.getNodeData('31');
 
-      expect(parameterizedElement1).to.be.an.instanceof(ParameterizedValueSnapshot);
-      expect(parameterizedElement1.inbound).to.have.deep.members([{ id: QueryRootId, path: ['one', 'two', 1, 'three'] }]);
-      expect(parameterizedElement1.outbound).to.have.deep.members([{ id: '31', path: [] }]);
-      expect(parameterizedElement1.data).to.eq(entityElement1);
+      expect(parameterizedElement1).toBeInstanceOf(ParameterizedValueSnapshot);
+      expect(parameterizedElement1.inbound).toEqual([{ id: QueryRootId, path: ['one', 'two', 1, 'three'] }]);
+      expect(parameterizedElement1.outbound).toEqual([{ id: '31', path: [] }]);
+      expect(parameterizedElement1.data).toBe(entityElement1);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/nestedParameterizedReferenceInArray.ts
+++ b/test/unit/operations/restore/parameterizedFields/nestedParameterizedReferenceInArray.ts
@@ -107,34 +107,34 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId0)).toBeInstanceOf(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('30')).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId1)).toBeInstanceOf(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('31')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId0)).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('30')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId1)).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('31')).toBeInstanceOf(EntitySnapshot);
     });
 
     it(`restores parameterized NodeSnapshot in an array at index=0 from JSON serialization object`, () => {
       const parameterizedElement0 = restoreGraphSnapshot.getNodeSnapshot(parameterizedId0)!;
       const entityElement0 = restoreGraphSnapshot.getNodeData('30');
 
-      expect(parameterizedElement0.inbound).toEqual([{ id: QueryRootId, path: ['one', 'two', 0, 'three'] }]);
-      expect(parameterizedElement0.outbound).toEqual([{ id: '30', path: [] }]);
-      expect(parameterizedElement0.data).toBe(entityElement0);
+      jestExpect(parameterizedElement0.inbound).toEqual([{ id: QueryRootId, path: ['one', 'two', 0, 'three'] }]);
+      jestExpect(parameterizedElement0.outbound).toEqual([{ id: '30', path: [] }]);
+      jestExpect(parameterizedElement0.data).toBe(entityElement0);
     });
 
     it(`restores parameterized NodeSnapshot at index=1 from JSON serialization object`, () => {
       const parameterizedElement1 = restoreGraphSnapshot.getNodeSnapshot(parameterizedId1)!;
       const entityElement1 = restoreGraphSnapshot.getNodeData('31');
 
-      expect(parameterizedElement1).toBeInstanceOf(ParameterizedValueSnapshot);
-      expect(parameterizedElement1.inbound).toEqual([{ id: QueryRootId, path: ['one', 'two', 1, 'three'] }]);
-      expect(parameterizedElement1.outbound).toEqual([{ id: '31', path: [] }]);
-      expect(parameterizedElement1.data).toBe(entityElement1);
+      jestExpect(parameterizedElement1).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(parameterizedElement1.inbound).toEqual([{ id: QueryRootId, path: ['one', 'two', 1, 'three'] }]);
+      jestExpect(parameterizedElement1.outbound).toEqual([{ id: '31', path: [] }]);
+      jestExpect(parameterizedElement1.data).toBe(entityElement1);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/nestedParameterizedReferencesWithParameterizedValue.ts
+++ b/test/unit/operations/restore/parameterizedFields/nestedParameterizedReferencesWithParameterizedValue.ts
@@ -82,23 +82,23 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('31')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('31')).toBeInstanceOf(EntitySnapshot);
     });
 
     it(`restores parameterized NodeSnapshot from JSON serialization object`, () => {
       const parameterizedNode = restoreGraphSnapshot.getNodeSnapshot(parameterizedId)!;
       const entityData = restoreGraphSnapshot.getNodeData('31');
 
-      expect(parameterizedNode.inbound).toEqual([{ id: QueryRootId, path: ['one', 'two'] }]);
-      expect(parameterizedNode.outbound).toEqual([{ id: '31', path: ['three'] }]);
-      expect(parameterizedNode.data).not.toBe(undefined);
-      expect(parameterizedNode.data!['three']).toBe(entityData);
+      jestExpect(parameterizedNode.inbound).toEqual([{ id: QueryRootId, path: ['one', 'two'] }]);
+      jestExpect(parameterizedNode.outbound).toEqual([{ id: '31', path: ['three'] }]);
+      jestExpect(parameterizedNode.data).not.toBe(undefined);
+      jestExpect(parameterizedNode.data!['three']).toBe(entityData);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/nestedParameterizedReferencesWithParameterizedValue.ts
+++ b/test/unit/operations/restore/parameterizedFields/nestedParameterizedReferencesWithParameterizedValue.ts
@@ -82,23 +82,23 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).to.be.an.instanceof(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('31')).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('31')).toBeInstanceOf(EntitySnapshot);
     });
 
     it(`restores parameterized NodeSnapshot from JSON serialization object`, () => {
       const parameterizedNode = restoreGraphSnapshot.getNodeSnapshot(parameterizedId)!;
       const entityData = restoreGraphSnapshot.getNodeData('31');
 
-      expect(parameterizedNode.inbound).to.has.deep.members([{ id: QueryRootId, path: ['one', 'two'] }]);
-      expect(parameterizedNode.outbound).to.has.deep.members([{ id: '31', path: ['three'] }]);
-      expect(parameterizedNode.data).not.eq(undefined);
-      expect(parameterizedNode.data!['three']).to.eq(entityData);
+      expect(parameterizedNode.inbound).toEqual([{ id: QueryRootId, path: ['one', 'two'] }]);
+      expect(parameterizedNode.outbound).toEqual([{ id: '31', path: ['three'] }]);
+      expect(parameterizedNode.data).not.toBe(undefined);
+      expect(parameterizedNode.data!['three']).toBe(entityData);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/nestedParameterizedValue.ts
+++ b/test/unit/operations/restore/parameterizedFields/nestedParameterizedValue.ts
@@ -60,12 +60,12 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/nestedParameterizedValue.ts
+++ b/test/unit/operations/restore/parameterizedFields/nestedParameterizedValue.ts
@@ -60,12 +60,12 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).to.be.an.instanceof(ParameterizedValueSnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/nestedParameterizedValueInArray.ts
+++ b/test/unit/operations/restore/parameterizedFields/nestedParameterizedValueInArray.ts
@@ -91,13 +91,13 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId0)).toBeInstanceOf(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId1)).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId0)).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId1)).toBeInstanceOf(ParameterizedValueSnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/nestedParameterizedValueInArray.ts
+++ b/test/unit/operations/restore/parameterizedFields/nestedParameterizedValueInArray.ts
@@ -91,13 +91,13 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId0)).to.be.an.instanceof(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId1)).to.be.an.instanceof(ParameterizedValueSnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId0)).toBeInstanceOf(ParameterizedValueSnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId1)).toBeInstanceOf(ParameterizedValueSnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/nestedParameterizedValueWithArrayOfNestedReferences.ts
+++ b/test/unit/operations/restore/parameterizedFields/nestedParameterizedValueWithArrayOfNestedReferences.ts
@@ -115,16 +115,16 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedTopContainerId)).toBeInstanceOf(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(nestedParameterizedValueId0)).toBeInstanceOf(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('31')).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(nestedParameterizedValueId1)).toBeInstanceOf(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('32')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(parameterizedTopContainerId)).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(nestedParameterizedValueId0)).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('31')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(nestedParameterizedValueId1)).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('32')).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/nestedParameterizedValueWithArrayOfNestedReferences.ts
+++ b/test/unit/operations/restore/parameterizedFields/nestedParameterizedValueWithArrayOfNestedReferences.ts
@@ -115,16 +115,16 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedTopContainerId)).to.be.an.instanceof(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(nestedParameterizedValueId0)).to.be.an.instanceof(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('31')).to.be.an.instanceof(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(nestedParameterizedValueId1)).to.be.an.instanceof(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('32')).to.be.an.instanceof(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedTopContainerId)).toBeInstanceOf(ParameterizedValueSnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(nestedParameterizedValueId0)).toBeInstanceOf(ParameterizedValueSnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('31')).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(nestedParameterizedValueId1)).toBeInstanceOf(ParameterizedValueSnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('32')).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/nestedParameterizedValueWithArrayOfNestedValues.ts
+++ b/test/unit/operations/restore/parameterizedFields/nestedParameterizedValueWithArrayOfNestedValues.ts
@@ -76,12 +76,12 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/nestedParameterizedValueWithArrayOfNestedValues.ts
+++ b/test/unit/operations/restore/parameterizedFields/nestedParameterizedValueWithArrayOfNestedValues.ts
@@ -76,12 +76,12 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).to.be.an.instanceof(ParameterizedValueSnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/nestedParameterizedValueWithNonParameterizedValue.ts
+++ b/test/unit/operations/restore/parameterizedFields/nestedParameterizedValueWithNonParameterizedValue.ts
@@ -69,12 +69,12 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/nestedParameterizedValueWithNonParameterizedValue.ts
+++ b/test/unit/operations/restore/parameterizedFields/nestedParameterizedValueWithNonParameterizedValue.ts
@@ -69,12 +69,12 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).to.be.an.instanceof(ParameterizedValueSnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/topLevelParameterizedReference.ts
+++ b/test/unit/operations/restore/parameterizedFields/topLevelParameterizedReference.ts
@@ -59,21 +59,21 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).to.be.an.instanceof(ParameterizedValueSnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
     });
 
     it(`restores parameterized RootQuery NodeSnapshot from JSON serialization object`, () => {
       const parameterizedNode = restoreGraphSnapshot.getNodeSnapshot(parameterizedId)!;
       const entityData = restoreGraphSnapshot.getNodeData('1');
 
-      expect(parameterizedNode.inbound).to.have.deep.members([{ id: QueryRootId, path: ['foo'] }]);
-      expect(parameterizedNode.outbound).to.have.deep.members([{ id: '1', path: [] }]);
-      expect(parameterizedNode.data).to.eq(entityData);
+      expect(parameterizedNode.inbound).toEqual([{ id: QueryRootId, path: ['foo'] }]);
+      expect(parameterizedNode.outbound).toEqual([{ id: '1', path: [] }]);
+      expect(parameterizedNode.data).toBe(entityData);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/topLevelParameterizedReference.ts
+++ b/test/unit/operations/restore/parameterizedFields/topLevelParameterizedReference.ts
@@ -59,21 +59,21 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
     });
 
     it(`restores parameterized RootQuery NodeSnapshot from JSON serialization object`, () => {
       const parameterizedNode = restoreGraphSnapshot.getNodeSnapshot(parameterizedId)!;
       const entityData = restoreGraphSnapshot.getNodeData('1');
 
-      expect(parameterizedNode.inbound).toEqual([{ id: QueryRootId, path: ['foo'] }]);
-      expect(parameterizedNode.outbound).toEqual([{ id: '1', path: [] }]);
-      expect(parameterizedNode.data).toBe(entityData);
+      jestExpect(parameterizedNode.inbound).toEqual([{ id: QueryRootId, path: ['foo'] }]);
+      jestExpect(parameterizedNode.outbound).toEqual([{ id: '1', path: [] }]);
+      jestExpect(parameterizedNode.data).toBe(entityData);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/topLevelParameterizedValue.ts
+++ b/test/unit/operations/restore/parameterizedFields/topLevelParameterizedValue.ts
@@ -52,12 +52,12 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).to.be.an.instanceof(ParameterizedValueSnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/topLevelParameterizedValue.ts
+++ b/test/unit/operations/restore/parameterizedFields/topLevelParameterizedValue.ts
@@ -52,12 +52,12 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/topLevelParameterizedValueNull.ts
+++ b/test/unit/operations/restore/parameterizedFields/topLevelParameterizedValueNull.ts
@@ -45,12 +45,12 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).to.be.an.instanceof(ParameterizedValueSnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/topLevelParameterizedValueNull.ts
+++ b/test/unit/operations/restore/parameterizedFields/topLevelParameterizedValueNull.ts
@@ -45,12 +45,12 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId)).toBeInstanceOf(ParameterizedValueSnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/topLevelValueWithDeeplyNestedParameterizedReferenceInArray.ts
+++ b/test/unit/operations/restore/parameterizedFields/topLevelValueWithDeeplyNestedParameterizedReferenceInArray.ts
@@ -116,15 +116,15 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId0)).to.be.an.instanceof(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('30')).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId1)).to.be.an.instanceof(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('31')).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId0)).toBeInstanceOf(ParameterizedValueSnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('30')).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId1)).toBeInstanceOf(ParameterizedValueSnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('31')).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/topLevelValueWithDeeplyNestedParameterizedReferenceInArray.ts
+++ b/test/unit/operations/restore/parameterizedFields/topLevelValueWithDeeplyNestedParameterizedReferenceInArray.ts
@@ -116,15 +116,15 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId0)).toBeInstanceOf(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('30')).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId1)).toBeInstanceOf(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('31')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId0)).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('30')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId1)).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('31')).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/topLevelValueWithNestedParameterizedReferenceInArray.ts
+++ b/test/unit/operations/restore/parameterizedFields/topLevelValueWithNestedParameterizedReferenceInArray.ts
@@ -110,15 +110,15 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
+      jestExpect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId0)).toBeInstanceOf(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('30')).toBeInstanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId1)).toBeInstanceOf(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('31')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId0)).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('30')).toBeInstanceOf(EntitySnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId1)).toBeInstanceOf(ParameterizedValueSnapshot);
+      jestExpect(restoreGraphSnapshot.getNodeSnapshot('31')).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/test/unit/operations/restore/parameterizedFields/topLevelValueWithNestedParameterizedReferenceInArray.ts
+++ b/test/unit/operations/restore/parameterizedFields/topLevelValueWithNestedParameterizedReferenceInArray.ts
@@ -110,15 +110,15 @@ describe(`operations.restore`, () => {
     });
 
     it(`restores GraphSnapshot from JSON serializable object`, () => {
-      expect(restoreGraphSnapshot).to.deep.eq(originalGraphSnapshot);
+      expect(restoreGraphSnapshot).toEqual(originalGraphSnapshot);
     });
 
     it(`correctly restores different types of NodeSnapshot`, () => {
-      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId0)).to.be.an.instanceof(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('30')).to.be.an.instanceOf(EntitySnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId1)).to.be.an.instanceof(ParameterizedValueSnapshot);
-      expect(restoreGraphSnapshot.getNodeSnapshot('31')).to.be.an.instanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(QueryRootId)).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId0)).toBeInstanceOf(ParameterizedValueSnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('30')).toBeInstanceOf(EntitySnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot(parameterizedId1)).toBeInstanceOf(ParameterizedValueSnapshot);
+      expect(restoreGraphSnapshot.getNodeSnapshot('31')).toBeInstanceOf(EntitySnapshot);
     });
 
   });

--- a/typings/global/test/base.d.ts
+++ b/typings/global/test/base.d.ts
@@ -6,6 +6,7 @@ declare global {
   namespace NodeJS {
     export interface Global {
       expect: typeof chai.expect;
+      jestExpect: typeof global.expect;
     }
   }
 }

--- a/typings/jest/index.d.ts
+++ b/typings/jest/index.d.ts
@@ -30,6 +30,7 @@ declare var fit: jest.It;
 declare var xit: jest.It;
 declare var test: jest.It;
 declare var xtest: jest.It;
+declare const jestExpect: jest.Expect;
 
 interface NodeRequire {
   /**


### PR DESCRIPTION
## What do!?

Adds `jestExpect` in parallel with chai `expect` (default).  Allows for the ability to translate tests piecemeal to jest.  Once complete can replace `jestExpect` with `expect`.

https://github.com/convoyinc/apollo-cache-hermes/issues/358

## Tests!

This PR adds jasmine support, and the converts all the tests under `unit/operations/restore` to Jasmine.

## Basic transitions:

- `to.eq`-> `toBe`
- `to.deep.eq` -> `toEqual`
- `to.have.deep.members` -> `toEqual` 
(from my understanding of `to.have.deep.members` it translated to `toEqual`)
- `to.be.an.instanceOf` -> `toBeInstanceOf`
- `to.throw` -> `toThrow`

