### PR TITLE
Only crawl nodeIds for observed queries

### DIFF
--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -227,12 +227,16 @@ export class Cache implements Queryable {
  */
 function _copyUnaffectedCachedReads(lastSnapshot: GraphSnapshot, nextSnapshot: GraphSnapshot, editedNodeIds: Set<NodeId>) {
   for (const [operation, result] of lastSnapshot.readCache) {
+    const { complete, entityIds, dynamicNodeIds } = result;
     // We don't care about incomplete results.
-    if (!result.complete) continue;
+    if (!complete) continue;
+    // Nor queries where we don't know which nodes were affected.
+    if (!entityIds) continue;
+
     // If any nodes in the cached read were edited, do not copy.
-    if ('entityIds' in result && setsHaveSomeIntersection(editedNodeIds, result.entityIds)) continue;
+    if (entityIds && setsHaveSomeIntersection(editedNodeIds, entityIds)) continue;
     // If any dynamic nodes were edited, also do not copy.
-    if (result.dynamicNodeIds && setsHaveSomeIntersection(editedNodeIds, result.dynamicNodeIds)) continue;
+    if (dynamicNodeIds && setsHaveSomeIntersection(editedNodeIds, dynamicNodeIds)) continue;
 
     nextSnapshot.readCache.set(operation, result);
   }

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -228,9 +228,11 @@ export class Cache implements Queryable {
 function _copyUnaffectedCachedReads(lastSnapshot: GraphSnapshot, nextSnapshot: GraphSnapshot, editedNodeIds: Set<NodeId>) {
   for (const [operation, result] of lastSnapshot.readCache) {
     // We don't care about incomplete results.
-    if (!result.complete || !('nodeIds' in result)) continue;
+    if (!result.complete) continue;
     // If any nodes in the cached read were edited, do not copy.
-    if (setsHaveSomeIntersection(editedNodeIds, result.nodeIds)) continue;
+    if ('entityIds' in result && setsHaveSomeIntersection(editedNodeIds, result.entityIds)) continue;
+    // If any dynamic nodes were edited, also do not copy.
+    if (result.dynamicNodeIds && setsHaveSomeIntersection(editedNodeIds, result.dynamicNodeIds)) continue;
 
     nextSnapshot.readCache.set(operation, result);
   }

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -10,7 +10,7 @@ import { JsonObject } from './primitive';
 import { Queryable } from './Queryable';
 import { ChangeId, NodeId, RawOperation, Serializable } from './schema';
 import { DocumentNode, setsHaveSomeIntersection } from './util';
-import { QueryResultWithNodeIds } from './operations/read';
+import { QueryResult } from './operations/read';
 
 export { MigrationMap };
 export type TransactionCallback = (transaction: CacheTransaction) => void;
@@ -45,7 +45,7 @@ export class Cache implements Queryable {
   restore(data: Serializable.GraphSnapshot, migrationMap?: MigrationMap, verifyQuery?: RawOperation) {
     const { cacheSnapshot, editedNodeIds } = restore(data, this._context);
     const migrated = migrate(cacheSnapshot, migrationMap);
-    if (verifyQuery && !read(this._context, verifyQuery, migrated.baseline).complete) {
+    if (verifyQuery && !read(this._context, verifyQuery, migrated.baseline, false).complete) {
       throw new Error(`Restored cache cannot satisfy the verification query`);
     }
     this._setSnapshot(migrated, editedNodeIds);
@@ -69,7 +69,7 @@ export class Cache implements Queryable {
    * TODO: Can we drop non-optimistic reads?
    * https://github.com/apollographql/apollo-client/issues/1971#issuecomment-319402170
    */
-  read(query: RawOperation, optimistic?: boolean): QueryResultWithNodeIds {
+  read(query: RawOperation, optimistic?: boolean): QueryResult {
     // TODO: Can we drop non-optimistic reads?
     // https://github.com/apollographql/apollo-client/issues/1971#issuecomment-319402170
     return read(this._context, query, optimistic ? this._snapshot.optimistic : this._snapshot.baseline);

--- a/src/operations/QueryObserver.ts
+++ b/src/operations/QueryObserver.ts
@@ -44,11 +44,16 @@ export class QueryObserver {
    * observing.
    */
   private _hasUpdate(_changedNodeIds: Set<NodeId>): boolean {
-    // TODO: Can we get to the point where this is not necessary?
-    if (!this._result!.complete) return true;
+    const { complete, entityIds, dynamicNodeIds } = this._result!;
+    if (!complete) return true;
+    // We can't know if we have no ids to test against. Favor updating.
+    if (!entityIds) return true;
+
     for (const nodeId of _changedNodeIds) {
-      if (this._result!.entityIds.has(nodeId)) return true;
+      if (entityIds.has(nodeId)) return true;
+      if (dynamicNodeIds && dynamicNodeIds.has(nodeId)) return true;
     }
+
     return false;
   }
 

--- a/src/operations/QueryObserver.ts
+++ b/src/operations/QueryObserver.ts
@@ -47,7 +47,7 @@ export class QueryObserver {
     // TODO: Can we get to the point where this is not necessary?
     if (!this._result!.complete) return true;
     for (const nodeId of _changedNodeIds) {
-      if (this._result!.nodeIds.has(nodeId)) return true;
+      if (this._result!.entityIds.has(nodeId)) return true;
     }
     return false;
   }

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -24,8 +24,9 @@ export interface QueryResultWithNodeIds extends QueryResult {
 /**
  * Get you some data.
  */
-export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSnapshot, includeNodeIds?: true): QueryResultWithNodeIds;
-export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSnapshot, includeNodeIds = true) {
+export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSnapshot, includeNodeIds: true): QueryResultWithNodeIds;
+export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSnapshot, includeNodeIds?: false): QueryResult;
+export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSnapshot, includeNodeIds = false) {
   let tracerContext;
   if (context.tracer.readStart) {
     tracerContext = context.tracer.readStart(raw);

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -14,6 +14,8 @@ export interface QueryResult {
   result?: JsonObject;
   /** Whether the query's selection set was satisfied. */
   complete: boolean;
+  /** The ids of entity nodes selected by the query. */
+  entityIds?: Set<NodeId>;
   /** The ids of nodes overlaid on top of static cache results. */
   dynamicNodeIds?: Set<NodeId>;
 }

--- a/test/unit/Cache/readCacheCarryForward.ts
+++ b/test/unit/Cache/readCacheCarryForward.ts
@@ -1,5 +1,6 @@
 import { query, strictConfig } from '../../helpers';
 import { Cache } from '../../../src';
+import { RawOperation } from '../../../src/schema';
 
 describe(`readCache carry-forward`, () => {
 
@@ -12,6 +13,13 @@ describe(`readCache carry-forward`, () => {
     }
   `);
 
+  function fullRead(cacheToReadFrom: Cache, queryToRead: RawOperation) {
+    // We only track ids for observed queries; not one-offs.
+    const unsubscribe = cacheToReadFrom.watch(queryToRead, () => {});
+    // observers synchronously trigger a full read; we can unsub now.
+    unsubscribe();
+  }
+
   let cache: Cache;
   beforeEach(() => {
     cache = new Cache(strictConfig);
@@ -21,13 +29,13 @@ describe(`readCache carry-forward`, () => {
     cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 1 } } });
 
     expect(cache.getSnapshot().baseline.readCache.size).to.eq(0);
-    cache.read({ ...thingQuery, variables: { id: 'a' } });
+    fullRead(cache, { ...thingQuery, variables: { id: 'a' } });
     expect(cache.getSnapshot().baseline.readCache.size).to.eq(1);
   });
 
   it(`carries cache results forward if no entities in the cached query were changed`, () => {
     cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 1 } } });
-    cache.read({ ...thingQuery, variables: { id: 'a' } });
+    fullRead(cache, { ...thingQuery, variables: { id: 'a' } });
 
     cache.write({ ...thingQuery, variables: { id: 'b' } }, { thing: { id: 'b', ref: { id: 1 } } });
     expect(cache.getSnapshot().baseline.readCache.size).to.eq(1);
@@ -35,7 +43,7 @@ describe(`readCache carry-forward`, () => {
 
   it(`drops cache results if entities in the cached query were changed`, () => {
     cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 1 } } });
-    cache.read({ ...thingQuery, variables: { id: 'a' } });
+    fullRead(cache, { ...thingQuery, variables: { id: 'a' } });
 
     cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 2 } } });
     expect(cache.getSnapshot().baseline.readCache.size).to.eq(0);
@@ -43,7 +51,7 @@ describe(`readCache carry-forward`, () => {
 
   it(`drops cache results if containing entities in the cached query were changed`, () => {
     cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 1 } } });
-    cache.read({ ...thingQuery, variables: { id: 'a' } });
+    fullRead(cache, { ...thingQuery, variables: { id: 'a' } });
 
     cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'b', ref: { id: 1 } } });
     expect(cache.getSnapshot().baseline.readCache.size).to.eq(0);

--- a/test/unit/operations/read/cyclicReferences.ts
+++ b/test/unit/operations/read/cyclicReferences.ts
@@ -64,8 +64,8 @@ describe(`operations.read`, () => {
       });
 
       it(`includes all related node ids, if requested`, () => {
-        const { nodeIds } = read(context, cyclicQuery, snapshot, true);
-        expect(Array.from(nodeIds)).to.have.members([QueryRootId, '1', '2']);
+        const { entityIds } = read(context, cyclicQuery, snapshot, true);
+        expect(Array.from(entityIds)).to.have.members([QueryRootId, '1', '2']);
       });
 
     });
@@ -122,8 +122,8 @@ describe(`operations.read`, () => {
       });
 
       it(`includes all related node ids, if requested`, () => {
-        const { nodeIds } = read(context, cyclicQuery, snapshot, true);
-        expect(Array.from(nodeIds)).to.have.members([QueryRootId, '1', '2']);
+        const { entityIds } = read(context, cyclicQuery, snapshot, true);
+        expect(Array.from(entityIds)).to.have.members([QueryRootId, '1', '2']);
       });
 
     });

--- a/test/unit/operations/read/noDynamicFeatures.ts
+++ b/test/unit/operations/read/noDynamicFeatures.ts
@@ -29,7 +29,7 @@ describe(`operations.read`, () => {
     });
 
     it(`includes no node ids if requested`, () => {
-      expect(Array.from(read(context, viewerQuery, empty, true).nodeIds)).to.have.members([]);
+      expect(Array.from(read(context, viewerQuery, empty, true).entityIds)).to.have.members([]);
     });
 
   });
@@ -62,8 +62,8 @@ describe(`operations.read`, () => {
     });
 
     it(`includes all related node ids, if requested`, () => {
-      const { nodeIds } = read(context, viewerQuery, snapshot, true);
-      expect(Array.from(nodeIds)).to.have.members([QueryRootId, '123']);
+      const { entityIds } = read(context, viewerQuery, snapshot, true);
+      expect(Array.from(entityIds)).to.have.members([QueryRootId, '123']);
     });
 
   });
@@ -95,8 +95,8 @@ describe(`operations.read`, () => {
     });
 
     it(`includes all related node ids, if requested`, () => {
-      const { nodeIds } = read(silentContext, viewerQuery, snapshot, true);
-      expect(Array.from(nodeIds)).to.have.members([QueryRootId, '123']);
+      const { entityIds } = read(silentContext, viewerQuery, snapshot, true);
+      expect(Array.from(entityIds)).to.have.members([QueryRootId, '123']);
     });
 
   });
@@ -137,8 +137,8 @@ describe(`operations.read`, () => {
     });
 
     it(`includes all related node ids, if requested`, () => {
-      const { nodeIds } = read(context, nestedQuery, snapshot, true);
-      expect(Array.from(nodeIds)).to.have.members([QueryRootId]);
+      const { entityIds } = read(context, nestedQuery, snapshot, true);
+      expect(Array.from(entityIds)).to.have.members([QueryRootId]);
     });
 
   });
@@ -173,8 +173,8 @@ describe(`operations.read`, () => {
     });
 
     it(`includes all related node ids, if requested`, () => {
-      const { nodeIds } = read(context, viewerQuery, snapshot, true);
-      expect(Array.from(nodeIds)).to.have.members([QueryRootId, '1', '2', '3']);
+      const { entityIds } = read(context, viewerQuery, snapshot, true);
+      expect(Array.from(entityIds)).to.have.members([QueryRootId, '1', '2', '3']);
     });
 
   });

--- a/test/unit/operations/read/parameterizedFields.ts
+++ b/test/unit/operations/read/parameterizedFields.ts
@@ -41,8 +41,8 @@ describe(`operations.read`, () => {
       });
 
       it(`returns the nodeIds visited during reading`, () => {
-        const { nodeIds } = read(context, parameterizedQuery, snapshot, true);
-        expect(Array.from(nodeIds)).to.have.members([
+        const { entityIds } = read(context, parameterizedQuery, snapshot, true);
+        expect(Array.from(entityIds)).to.have.members([
           QueryRootId,
           nodeIdForParameterizedValue(QueryRootId, ['user'], { id: 1, withExtra: true }),
           '1',
@@ -113,8 +113,8 @@ describe(`operations.read`, () => {
         });
 
         it(`returns the nodeIds visited during reading`, () => {
-          const { nodeIds } = read(context, nestedQuery, snapshot, true);
-          expect(Array.from(nodeIds)).to.have.members([
+          const { entityIds } = read(context, nestedQuery, snapshot, true);
+          expect(Array.from(entityIds)).to.have.members([
             QueryRootId,
             nodeIdForParameterizedValue(QueryRootId, ['one', 'two'], { id: 1 }),
             '1',

--- a/test/unit/operations/read/parameterizedFields.ts
+++ b/test/unit/operations/read/parameterizedFields.ts
@@ -41,11 +41,13 @@ describe(`operations.read`, () => {
       });
 
       it(`returns the nodeIds visited during reading`, () => {
-        const { entityIds } = read(context, parameterizedQuery, snapshot, true);
+        const { entityIds, dynamicNodeIds } = read(context, parameterizedQuery, snapshot, true);
         expect(Array.from(entityIds)).to.have.members([
           QueryRootId,
-          nodeIdForParameterizedValue(QueryRootId, ['user'], { id: 1, withExtra: true }),
           '1',
+        ]);
+        expect(Array.from(dynamicNodeIds!)).to.have.members([
+          nodeIdForParameterizedValue(QueryRootId, ['user'], { id: 1, withExtra: true }),
         ]);
       });
 
@@ -113,13 +115,15 @@ describe(`operations.read`, () => {
         });
 
         it(`returns the nodeIds visited during reading`, () => {
-          const { entityIds } = read(context, nestedQuery, snapshot, true);
+          const { entityIds, dynamicNodeIds } = read(context, nestedQuery, snapshot, true);
           expect(Array.from(entityIds)).to.have.members([
             QueryRootId,
-            nodeIdForParameterizedValue(QueryRootId, ['one', 'two'], { id: 1 }),
             '1',
-            nodeIdForParameterizedValue('1', ['three', 'four'], { extra: true }),
             '2',
+          ]);
+          expect(Array.from(dynamicNodeIds!)).to.have.members([
+            nodeIdForParameterizedValue(QueryRootId, ['one', 'two'], { id: 1 }),
+            nodeIdForParameterizedValue('1', ['three', 'four'], { extra: true }),
             nodeIdForParameterizedValue('2', ['three', 'four'], { extra: true }),
           ]);
         });


### PR DESCRIPTION
No more walking entire one-off queries to collect nodeIds