### PR TITLE
Expose strict mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,8 @@
       "name": "test-unit",
       "runtimeExecutable": "${workspaceRoot}/scripts/test-unit.sh",
       "runtimeArgs": [
-        "--runInBand"
+        "--runInBand",
+        "${relativeFile}",
       ]
     }
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-cache-hermes",
-  "version": "0.8.0-beta",
+  "version": "0.8.0",
   "description": "A cache implementation for Apollo Client, tuned for performance",
   "license": "Apache-2.0",
   "repository": "convoyinc/apollo-cache-hermes",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-cache-hermes",
-  "version": "0.7.0",
+  "version": "0.8.0-beta",
   "description": "A cache implementation for Apollo Client, tuned for performance",
   "license": "Apache-2.0",
   "repository": "convoyinc/apollo-cache-hermes",

--- a/src/context/CacheContext.ts
+++ b/src/context/CacheContext.ts
@@ -123,6 +123,11 @@ export namespace CacheContext {
     tracer?: Tracer;
 
     /**
+     * Whether strict mode is enabled (defaults to true).
+     */
+    strict?: boolean;
+
+    /**
      * Whether debugging information should be logged out.
      *
      * Enabling this will cause the cache to emit log events for most operations
@@ -168,6 +173,9 @@ export class CacheContext {
   /** Configured on-change callback */
   readonly onChange: CacheContext.OnChangeCallback | undefined;
 
+  /** Whether the cache should operate in strict mode. */
+  readonly strict: boolean;
+
   /** The tracer we should use. */
   readonly tracer: Tracer;
 
@@ -186,6 +194,7 @@ export class CacheContext {
     this.entityTransformer = config.entityTransformer;
     this.freezeSnapshots = 'freeze' in config ? !!config.freeze : nodeEnv !== 'production';
 
+    this.strict = typeof config.strict === 'boolean' ? config.strict : true;
     this.verbose = !!config.verbose;
     this.resolverRedirects = config.resolverRedirects || {};
     this.onChange = config.onChange;

--- a/src/operations/QueryObserver.ts
+++ b/src/operations/QueryObserver.ts
@@ -2,7 +2,7 @@ import { CacheContext } from '../context';
 import { GraphSnapshot } from '../GraphSnapshot';
 import { NodeId, RawOperation } from '../schema';
 
-import { QueryResult, QueryResultWithNodeIds, read } from './read';
+import { QueryResult, read } from './read';
 
 export type Callback = (result: QueryResult) => void;
 
@@ -18,7 +18,7 @@ export class QueryObserver {
   /** The query being observed. */
   private _query: RawOperation;
   /** The most recent result */
-  private _result?: QueryResultWithNodeIds;
+  private _result?: QueryResult;
   /** The callback to trigger when observed nodes have changed. */
   private _callback: Callback;
 
@@ -61,7 +61,11 @@ export class QueryObserver {
    * Re-query and trigger the callback.
    */
   private _update(snapshot: GraphSnapshot): void {
-    this._result = read(this._context, this._query, snapshot, true);
+    // Note that if strict mode is disabled, we _do not_ ask for node ids.
+    //
+    // This effectively circumvents the logic in _hasUpdate (entityIds will be
+    // undefined).
+    this._result = read(this._context, this._query, snapshot, this._context.strict);
     this._callback(this._result);
   }
 

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -37,23 +37,24 @@ export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSn
   }
 
   const operation = context.parseOperation(raw);
-  let queryResult = snapshot.readCache.get(operation) as Partial<QueryResultWithNodeIds>;
-  let cacheHit = true;
-  if (!queryResult) {
-    cacheHit = false;
-    const staticResult = snapshot.getNodeData(operation.rootId);
 
-    let result = staticResult;
-    const dynamicNodeIds = operation.isStatic ? undefined : new Set<NodeId>();
+  // Retrieve the previous result (may be partially complete), or start anew.
+  const queryResult = snapshot.readCache.get(operation) || {} as Partial<QueryResultWithNodeIds>;
+  snapshot.readCache.set(operation, queryResult as QueryResult);
+
+  let cacheHit = true;
+  if (!queryResult.result) {
+    cacheHit = false;
+    queryResult.result = snapshot.getNodeData(operation.rootId);
+
     if (!operation.isStatic) {
-      result = _walkAndOverlayDynamicValues(operation, context, snapshot, staticResult, dynamicNodeIds!);
+      const dynamicNodeIds = new Set<NodeId>();
+      queryResult.result = _walkAndOverlayDynamicValues(operation, context, snapshot, queryResult.result, dynamicNodeIds!);
+      queryResult.dynamicNodeIds = dynamicNodeIds;
     }
 
-    const entityIds = includeNodeIds ? new Set<NodeId>() : undefined;
-    const complete = _visitSelection(operation, context, result, entityIds);
-
-    queryResult = { result, complete, entityIds, dynamicNodeIds };
-    snapshot.readCache.set(operation, queryResult as QueryResult);
+    queryResult.entityIds = includeNodeIds ? new Set<NodeId>() : undefined;
+    queryResult.complete = _visitSelection(operation, context, queryResult.result, queryResult.entityIds);
   }
 
   // We can potentially ask for results without node ids first, and then follow

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -54,7 +54,12 @@ export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSn
     }
 
     queryResult.entityIds = includeNodeIds ? new Set<NodeId>() : undefined;
-    queryResult.complete = _visitSelection(operation, context, queryResult.result, queryResult.entityIds);
+
+    // When strict mode is disabled, we carry completeness forward for observed
+    // queries.  Once complete, always complete.
+    if (typeof queryResult.complete !== 'boolean') {
+      queryResult.complete = _visitSelection(operation, context, queryResult.result, queryResult.entityIds);
+    }
   }
 
   // We can potentially ask for results without node ids first, and then follow

--- a/src/operations/read.ts
+++ b/src/operations/read.ts
@@ -29,7 +29,7 @@ export interface QueryResultWithNodeIds extends QueryResult {
  * Get you some data.
  */
 export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSnapshot, includeNodeIds: true): QueryResultWithNodeIds;
-export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSnapshot, includeNodeIds?: false): QueryResult;
+export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSnapshot, includeNodeIds?: boolean): QueryResult;
 export function read(context: CacheContext, raw: RawOperation, snapshot: GraphSnapshot, includeNodeIds?: boolean) {
   let tracerContext;
   if (context.tracer.readStart) {

--- a/test/unit/Cache/readCacheCarryForward.ts
+++ b/test/unit/Cache/readCacheCarryForward.ts
@@ -81,7 +81,7 @@ describe(`readCache carry-forward`, () => {
       fullRead(cache, { ...thingQuery, variables: { id: 'a' } });
       cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 2 } } });
 
-      const values = Array.from(cache.getSnapshot().baseline.readCache.values())
+      const values = Array.from(cache.getSnapshot().baseline.readCache.values());
       expect(values).to.deep.eq([{ complete: true }]);
     });
 

--- a/test/unit/Cache/readCacheCarryForward.ts
+++ b/test/unit/Cache/readCacheCarryForward.ts
@@ -20,41 +20,84 @@ describe(`readCache carry-forward`, () => {
     unsubscribe();
   }
 
-  let cache: Cache;
-  beforeEach(() => {
-    cache = new Cache(strictConfig);
+  describe(`with strict mode enabled`, () => {
+
+    let cache: Cache;
+    beforeEach(() => {
+      cache = new Cache(strictConfig);
+    });
+
+    it(`memoizes read results`, () => {
+      cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 1 } } });
+
+      expect(cache.getSnapshot().baseline.readCache.size).to.eq(0);
+      fullRead(cache, { ...thingQuery, variables: { id: 'a' } });
+      expect(cache.getSnapshot().baseline.readCache.size).to.eq(1);
+    });
+
+    it(`carries cache results forward if no entities in the cached query were changed`, () => {
+      cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 1 } } });
+      fullRead(cache, { ...thingQuery, variables: { id: 'a' } });
+
+      cache.write({ ...thingQuery, variables: { id: 'b' } }, { thing: { id: 'b', ref: { id: 1 } } });
+      expect(cache.getSnapshot().baseline.readCache.size).to.eq(1);
+    });
+
+    it(`drops cache results if entities in the cached query were changed`, () => {
+      cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 1 } } });
+      fullRead(cache, { ...thingQuery, variables: { id: 'a' } });
+
+      cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 2 } } });
+      expect(cache.getSnapshot().baseline.readCache.size).to.eq(0);
+    });
+
+    it(`drops cache results if containing entities in the cached query were changed`, () => {
+      cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 1 } } });
+      fullRead(cache, { ...thingQuery, variables: { id: 'a' } });
+
+      cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'b', ref: { id: 1 } } });
+      expect(cache.getSnapshot().baseline.readCache.size).to.eq(0);
+    });
+
   });
 
-  it(`the cache memoizes read results`, () => {
-    cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 1 } } });
+  describe(`with strict mode disabled`, () => {
 
-    expect(cache.getSnapshot().baseline.readCache.size).to.eq(0);
-    fullRead(cache, { ...thingQuery, variables: { id: 'a' } });
-    expect(cache.getSnapshot().baseline.readCache.size).to.eq(1);
-  });
+    let cache: Cache;
+    beforeEach(() => {
+      cache = new Cache({ ...strictConfig, strict: false });
+    });
 
-  it(`carries cache results forward if no entities in the cached query were changed`, () => {
-    cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 1 } } });
-    fullRead(cache, { ...thingQuery, variables: { id: 'a' } });
+    it(`memoizes read results`, () => {
+      cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 1 } } });
 
-    cache.write({ ...thingQuery, variables: { id: 'b' } }, { thing: { id: 'b', ref: { id: 1 } } });
-    expect(cache.getSnapshot().baseline.readCache.size).to.eq(1);
-  });
+      expect(cache.getSnapshot().baseline.readCache.size).to.eq(0);
+      fullRead(cache, { ...thingQuery, variables: { id: 'a' } });
+      expect(cache.getSnapshot().baseline.readCache.size).to.eq(1);
+    });
 
-  it(`drops cache results if entities in the cached query were changed`, () => {
-    cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 1 } } });
-    fullRead(cache, { ...thingQuery, variables: { id: 'a' } });
+    it(`carries completeness forward, even if entities have changed`, () => {
+      cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 1 } } });
+      fullRead(cache, { ...thingQuery, variables: { id: 'a' } });
+      cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 2 } } });
 
-    cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 2 } } });
-    expect(cache.getSnapshot().baseline.readCache.size).to.eq(0);
-  });
+      const values = Array.from(cache.getSnapshot().baseline.readCache.values())
+      expect(values).to.deep.eq([{ complete: true }]);
+    });
 
-  it(`drops cache results if containing entities in the cached query were changed`, () => {
-    cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 1 } } });
-    fullRead(cache, { ...thingQuery, variables: { id: 'a' } });
+    it(`doesn't carry results forward`, () => {
+      cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'a', ref: { id: 1 } } });
+      fullRead(cache, { ...thingQuery, variables: { id: 'a' } });
+      cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'b', ref: { id: 2 } } });
 
-    cache.write({ ...thingQuery, variables: { id: 'a' } }, { thing: { id: 'b', ref: { id: 1 } } });
-    expect(cache.getSnapshot().baseline.readCache.size).to.eq(0);
+      const { result } = cache.read({ ...thingQuery, variables: { id: 'a' } });
+      expect(result).to.deep.eq({
+        thing: {
+          id: 'b',
+          ref: { id: 2 },
+        },
+      });
+    });
   });
 
 });


### PR DESCRIPTION
By default, strict mode is enabled. If you disable it:

* The cache will assume that any complete read will stay complete. Whether this is safe is application-dependent. Docs forthcoming.
* This allows us to skip the walk of results for any observed query, which is the majority of Hermes' time spent.