### PR TITLE
Extended error message for mismatches in id existence within payload

### DIFF
--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -18,6 +18,7 @@ import {
   removeNodeReference,
 } from '../util';
 
+const ensureIdConstistencyMsg = `Ensure id is included (or not included) consistently across multiple requests.`;
 /**
  * A newly modified snapshot.
  */
@@ -166,12 +167,12 @@ export class SnapshotEditor {
     if (payloadId !== previousId) {
       // It is invalid to transition from a *value* with an id to one without.
       if (!isNil(payload) && !payloadId) {
-        const message = `Unsupported transition from an entity to a non-entity value`;
+        const message = `Unsupported transition from an entity to a non-entity value. ${ensureIdConstistencyMsg}`;
         throw new InvalidPayloadError(message, prefixPath, containerId, path, payload);
       }
       // The reverse is also invalid.
       if (!isNil(previousValue) && !previousId) {
-        const message = `Unsupported transition from a non-entity value to an entity`;
+        const message = `Unsupported transition from a non-entity value to an entity. ${ensureIdConstistencyMsg}`;
         throw new InvalidPayloadError(message, prefixPath, containerId, path, payload);
       }
       // Double check that our id generator is behaving properly.


### PR DESCRIPTION
Extending the error message for mismatches in id existence within payload.  We hit this error without much context into the actual cause.

<img width="432" alt="screen shot 2019-01-17 at 11 45 26 am" src="https://user-images.githubusercontent.com/2730654/51344451-86548200-1a4d-11e9-9f10-fd970a7c26e8.png">
