### PR TITLE
add warning around missing __typename in fragment payload

### DIFF
--- a/src/context/CacheContext.ts
+++ b/src/context/CacheContext.ts
@@ -180,7 +180,8 @@ export class CacheContext {
   readonly tracer: Tracer;
 
   /** Whether __typename should be injected into nodes in queries. */
-  private readonly _addTypename: boolean;
+  readonly addTypename: boolean;
+
   /** All currently known & processed GraphQL documents. */
   private readonly _queryInfoMap = new Map<string, QueryInfo>();
   /** All currently known & parsed queries, for identity mapping. */
@@ -201,15 +202,7 @@ export class CacheContext {
     this.entityUpdaters = config.entityUpdaters || {};
     this.tracer = config.tracer || new ConsoleTracer(!!config.verbose, config.logger);
 
-    this._addTypename = config.addTypename || false;
-  }
-
-  /**
-   * Returns a boolean indicating whether this CacheContext has been
-   * configured to add __typename when transforming documents.
-   */
-  getAddTypename() {
-    return this._addTypename;
+    this.addTypename = config.addTypename || false;
   }
 
   /**
@@ -219,7 +212,7 @@ export class CacheContext {
    * any other method in the cache.
    */
   transformDocument(document: DocumentNode): DocumentNode {
-    if (this._addTypename && !document.hasBeenTransformed) {
+    if (this.addTypename && !document.hasBeenTransformed) {
       const transformedDocument = addTypenameToDocument(document);
       transformedDocument.hasBeenTransformed = true;
       return transformedDocument;

--- a/src/context/CacheContext.ts
+++ b/src/context/CacheContext.ts
@@ -205,6 +205,14 @@ export class CacheContext {
   }
 
   /**
+   * Returns a boolean indicating whether this CacheContext has been
+   * configured to add __typename when transforming documents.
+   */
+  getAddTypename() {
+    return this._addTypename;
+  }
+
+  /**
    * Performs any transformations of operation documents.
    *
    * Cache consumers should call this on any operation document prior to calling

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -223,6 +223,13 @@ export class SnapshotEditor {
         if (payload && payloadName in payload) {
           warnings.push(`Encountered undefined at ${[...prefixPath, ...path].join('.')}. Treating as null`);
         }
+
+        if (this._context.getAddTypename() && payloadName === '__typename') {
+          const existingTypenameValue = deepGet(this._getNodeData(containerId), path);
+          if (existingTypenameValue) {
+            warnings.push(`Encountered undefined payload value for __typename which will override __typename value on existing fragment.`);
+          }
+        }
       }
 
       let containerIdForField = containerId;

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -224,11 +224,8 @@ export class SnapshotEditor {
           warnings.push(`Encountered undefined at ${[...prefixPath, ...path].join('.')}. Treating as null`);
         }
 
-        if (this._context.getAddTypename() && payloadName === '__typename') {
-          const existingTypenameValue = deepGet(this._getNodeData(containerId), path);
-          if (existingTypenameValue) {
-            warnings.push(`Encountered undefined payload value for __typename which will override __typename value on existing fragment.`);
-          }
+        if (this._context.addTypename && payloadName === '__typename') {
+          warnings.push(`Encountered undefined payload value for __typename which will override __typename value on existing fragment.`);
         }
       }
 

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -225,7 +225,8 @@ export class SnapshotEditor {
         }
 
         if (this._context.addTypename && payloadName === '__typename') {
-          warnings.push(`Encountered undefined payload value for __typename which will override __typename value on existing fragment.`);
+          const message = `Encountered undefined payload value for __typename which will override __typename value on existing fragment`;
+          throw new InvalidPayloadError(message, prefixPath, containerId, path, payload);
         }
       }
 

--- a/test/unit/Apollo/writeFragment/errorMissingTypename.ts
+++ b/test/unit/Apollo/writeFragment/errorMissingTypename.ts
@@ -1,0 +1,37 @@
+import gql from 'graphql-tag';
+
+import { Hermes } from '../../../../src/apollo/Hermes';
+import { strictConfig } from '../../../helpers/context';
+import { StaticNodeId } from '../../../../src/schema';
+
+const { QueryRoot: QueryRootId } = StaticNodeId;
+
+describe(`writeFragment with missing __typename`, () => {
+
+  let hermes: Hermes;
+  beforeAll(() => {
+    hermes = new Hermes({
+      ...strictConfig,
+      addTypename: true,
+    });
+  });
+
+  it(`throws an error`, () => {
+    expect(() => {
+      hermes.writeFragment({
+        id: QueryRootId,
+        fragment: gql(`
+          fragment viewer on Viewer {
+            id
+            name
+          }
+        `),
+        data: {
+          id: 123,
+          name: 'Gouda',
+        },
+      });
+    }).to.throw(/InvalidPayloadError: Encountered undefined payload value for __typename/i);
+  });
+
+});

--- a/test/unit/context/CacheContext/addTypeName.ts
+++ b/test/unit/context/CacheContext/addTypeName.ts
@@ -30,6 +30,8 @@ describe(`context.CacheContext`, () => {
         }
       }`);
 
+      expect(context.addTypename).to.eq(false);
+
       const rootSelection = parsed.info.operation.selectionSet;
       expect(fieldNames(rootSelection)).to.have.members(['foo']);
 
@@ -47,6 +49,8 @@ describe(`context.CacheContext`, () => {
           bar { a b }
         }
       }`);
+
+      expect(context.addTypename).to.eq(true);
 
       const rootSelection = parsed.info.operation.selectionSet;
       expect(fieldNames(rootSelection)).to.have.members(['foo']);


### PR DESCRIPTION
✔ Write a summary

Add warning around missing __typename in fragment payload. See #412. This is my attempt to add a warning around this condition. Note that the warning is only emitted if verbose logging is enabled so I'm not sure how helpful it'll be.

✔ Tests!

N/A

✔ Bump the version if needed

N/A
