### PR TITLE
Parameterized entities with multi dimensional arrays

### DIFF
--- a/test/unit/operations/read/noDynamicFeatures.ts
+++ b/test/unit/operations/read/noDynamicFeatures.ts
@@ -179,4 +179,28 @@ describe(`operations.read`, () => {
 
   });
 
+  describe(`with arrays of arrays of complete values`, () => {
+
+    let snapshot: GraphSnapshot;
+    beforeAll(() => {
+      snapshot = write(context, empty, viewerQuery, {
+        viewer: [
+          [{ id: 1, name: 'Foo' }],
+          [{ id: 2, name: 'Bar' }],
+          [{ id: 3, name: 'Baz' }],
+        ],
+      }).snapshot;
+    });
+
+    it(`returns the selected values.`, () => {
+      const { result } = read(context, viewerQuery, snapshot);
+      jestExpect(result).toEqual({
+        viewer: [
+          [{ id: 1, name: 'Foo' }],
+          [{ id: 2, name: 'Bar' }],
+          [{ id: 3, name: 'Baz' }],
+        ],
+      });
+    });
+  });
 });

--- a/test/unit/operations/read/parameterizedFields.ts
+++ b/test/unit/operations/read/parameterizedFields.ts
@@ -300,6 +300,52 @@ describe(`operations.read`, () => {
 
     });
 
+    describe(`with multi-dimensional array fields`, () => {
+
+      const nestedQuery = query(`query multiDimensional($id: ID!) {
+        listOfLists {
+          foo {
+            stuff(id: $id) {
+              bar
+            }
+          }
+        }
+      }`, { id: 1 });
+
+      let snapshot: GraphSnapshot;
+
+      beforeAll(() => {
+        snapshot = write(context, empty, nestedQuery, {
+          listOfLists: [
+            [
+              { foo: { stuff: { bar: 1 } } },
+              { foo: { stuff: { bar: 2 } } },
+            ],
+            [
+              { foo: { stuff: { bar: 3 } } },
+              { foo: { stuff: { bar: 4 } } },
+            ],
+          ],
+        }).snapshot;
+      });
+
+      it(`returns the selected values, overlaid on the underlying data`, () => {
+        const { result } = read(context, nestedQuery, snapshot);
+        jestExpect(result).toEqual({
+          listOfLists: [
+            [
+              { foo: { stuff: { bar: 1 } } },
+              { foo: { stuff: { bar: 2 } } },
+            ],
+            [
+              { foo: { stuff: { bar: 3 } } },
+              { foo: { stuff: { bar: 4 } } },
+            ],
+          ],
+        });
+      });
+    });
+
     describe(`directly nested reference fields`, () => {
 
       const nestedQuery = query(`


### PR DESCRIPTION
<!--
Thanks for helping out!  To make sure your pull request goes smoothly, here's a quick checklist to walk through:

✔ Write a summary

Please summarize your change, and provide as much context as you can.  What's your motivation for the change?  Why'd you take this approach?  Links to related issues?  Etc.  Helps the reviewer give more thoughtful feedback.

✔ Tests!

This repository requires a decent amount of coverage on all changes, in an effort to keep master green.  So, please write tests for any new feature you write - and, if possible, regression tests for bugs you've fixed.

✔ Bump the version if needed

This repository automatically publishes every commit on master to npm, and increments the Z version for you.  So:

* Fixing a bug?  Thanks!
  You don't need to touch the version.

* Adding a new, backwards-compatible, feature?  Sweet!
  Please increment the Y version in package.json.

* Making a breaking change to an existing API?  Welp, that's how it goes.
  Please increment the X version in package.json.

-->

Hermes is not able to resolve parameterized nodes that are nested in a multi-dimensional array. Writes to the cache in this scenario is correct, but on reads, we were not calculating the path of the parameterized nodes correctly. This happens because multi-dimensional arrays were not considered when [traversing children](https://github.com/convoyinc/apollo-cache-hermes/blob/3d44bd1c01ab683531a0ab2fd3599571ba715eb3/src/operations/read.ts#L176). This change looks for the GraphQL objects at any depth.