### PR TITLE
Update apollo client to v3 and TypeScript to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
     "@types/chai": "^4.0.10",
     "@types/chai-as-promised": "^7.1.0",
     "@types/deep-freeze-strict": "^1.1.0",
-    "@types/graphql": "^0.12.4",
     "@types/lodash": "^4.14.102",
     "@types/lodash.findindex": "^4.6.3",
     "@types/lodash.isequal": "^4.3.3",
     "@types/lodash.set": "^4.3.3",
-    "@types/node": "^8.9.4",
+    "@types/node": "^14.0.27",
+    "@types/react": "^16.9.44",
     "audit-ci": "^2.4.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
@@ -53,23 +53,29 @@
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jest": "^22.0.0",
     "eslint-plugin-typescript": "^0.12.0",
-    "graphql": "^0.13.1",
-    "graphql-tag": "^2.6.0",
+    "graphql": "^15.3.0",
+    "graphql-tag": "^2.11.0",
     "jest": "^23.0.0",
     "jest-junit": "^5.0.0",
     "lodash": "^4.17.5",
+    "react": "^16.13.1",
     "rimraf": "^2.6.2",
-    "typescript": "~2.8.0",
+    "typescript": "^3.9.7",
     "typescript-eslint-parser": "^20.0.0"
   },
   "dependencies": {
-    "apollo-cache": "^1.0.0",
-    "apollo-utilities": "^1.0.0",
+    "@apollo/client": "^3.1.2",
+    "@wry/equality": "^0.2.0",
     "deep-freeze-strict": "^1.0.0",
     "lodash.findindex": "^4.0.0",
     "lodash.isequal": "^4.5.0",
     "lodash.set": "^4.0.0",
     "make-error": "^1.3.0",
-    "tslib": "^1.9.0"
+    "subscriptions-transport-ws": "^0.9.17",
+    "ts-invariant": "^0.4.4",
+    "tslib": "^2.0.0"
+  },
+  "peerDependencies": {
+    "@apollo/client": "^3.1.2"
   }
 }

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -1,4 +1,4 @@
-import { Cache as CacheInterface } from 'apollo-cache';
+import { Cache as CacheInterface } from '@apollo/client';
 
 import { CacheSnapshot } from './CacheSnapshot';
 import { CacheTransaction } from './CacheTransaction';
@@ -57,10 +57,6 @@ export class Cache implements Queryable {
       pruneQuery ? prune(this._context, cacheSnapshot, pruneQuery).snapshot : cacheSnapshot,
       this._context
     );
-  }
-
-  evict(_query: RawOperation): { success: boolean } { // eslint-disable-line class-methods-use-this
-    throw new Error(`evict() is not implemented on Cache`);
   }
 
   /**

--- a/src/CacheTransaction.ts
+++ b/src/CacheTransaction.ts
@@ -91,14 +91,6 @@ export class CacheTransaction implements Queryable {
   }
 
   /**
-   * Removes values from the current transaction
-   */
-  // eslint-disable-next-line class-methods-use-this
-  evict(_query: RawOperation): { success: boolean } {
-    throw new Error('evict() is not implemented on CacheTransaction');
-  }
-
-  /**
    * Complete the transaction, returning the new snapshot and the ids of any
    * nodes that were edited.
    */

--- a/src/ParsedQueryNode.ts
+++ b/src/ParsedQueryNode.ts
@@ -1,4 +1,4 @@
-import { isEqual, valueFromNode } from 'apollo-utilities';
+import isEqual from '@wry/equality';
 
 import { CacheContext } from './context';
 import { ConflictingFieldsError } from './errors';
@@ -11,6 +11,7 @@ import {
   ValueNode,
   isObject,
   fieldHasStaticDirective,
+  valueFromNode,
 } from './util';
 
 export type JsonAndVariables = JsonScalar | VariableArgument;
@@ -187,7 +188,7 @@ export function areChildrenDynamic(children?: ParsedQueryWithVariables) {
 /**
  * Build the map of arguments to their natural JS values (or variables).
  */
-function _buildFieldArgs(variables: Set<string>, argumentsNode?: ArgumentNode[]) {
+function _buildFieldArgs(variables: Set<string>, argumentsNode?: readonly ArgumentNode[]) {
   if (!argumentsNode) return undefined;
 
   const args = {};

--- a/src/Queryable.ts
+++ b/src/Queryable.ts
@@ -28,10 +28,4 @@ export interface Queryable {
    * Writes values for a selection to the cache.
    */
   write(query: RawOperation, payload: JsonObject): void;
-
-  /**
-   * Removes values for a selection to the cache
-   */
-  evict(query: RawOperation): { success: boolean };
-
 }

--- a/src/apollo/Hermes.ts
+++ b/src/apollo/Hermes.ts
@@ -2,11 +2,11 @@ import {
   Transaction,
   Cache as CacheInterface,
   ApolloCache,
-} from 'apollo-cache';
+} from '@apollo/client';
 
+import { CacheContext } from '../context';
 import { Cache, MigrationMap } from '../Cache';
 import { CacheSnapshot } from '../CacheSnapshot';
-import { CacheContext } from '../context';
 import { GraphSnapshot } from '../GraphSnapshot';
 
 import { ApolloQueryable } from './Queryable';
@@ -16,7 +16,7 @@ import { buildRawOperationFromQuery } from './util';
 /**
  * Apollo-specific interface to the cache.
  */
-export class Hermes extends ApolloQueryable implements ApolloCache<GraphSnapshot> {
+export class Hermes extends ApolloQueryable<GraphSnapshot> {
   /** The underlying Hermes cache. */
   protected _queryable: Cache;
 

--- a/src/apollo/Transaction.ts
+++ b/src/apollo/Transaction.ts
@@ -1,10 +1,9 @@
-import { ApolloCache, Cache, Transaction } from 'apollo-cache';
-import { JsonValue } from 'apollo-utilities';
+import { Cache, Transaction } from '@apollo/client';
 import lodashIsEqual = require('lodash.isequal');
 
 import { CacheTransaction } from '../CacheTransaction';
 import { GraphSnapshot } from '../GraphSnapshot';
-import { PathPart } from '../primitive';
+import { PathPart, JsonValue } from '../primitive';
 import { NodeId } from '../schema';
 import { DocumentNode, verboseTypeof, deepGet } from '../util';
 
@@ -22,7 +21,7 @@ function getOriginalFieldArguments(id: NodeId): { [argName: string]: string } | 
 /**
  * Apollo-specific transaction interface.
  */
-export class ApolloTransaction extends ApolloQueryable implements ApolloCache<GraphSnapshot> {
+export class ApolloTransaction extends ApolloQueryable<GraphSnapshot> {
 
   constructor(
     /** The underlying transaction. */

--- a/src/apollo/util.ts
+++ b/src/apollo/util.ts
@@ -1,4 +1,4 @@
-import { getFragmentQueryDocument } from 'apollo-utilities';
+import { getFragmentQueryDocument } from '@apollo/client/utilities';
 
 import { JsonObject } from '../primitive';
 import { NodeId, RawOperation, StaticNodeId } from '../schema';

--- a/src/context/CacheContext.ts
+++ b/src/context/CacheContext.ts
@@ -1,4 +1,5 @@
-import { addTypenameToDocument, isEqual } from 'apollo-utilities';
+import { addTypenameToDocument } from '@apollo/client/utilities';
+import isEqual from '@wry/equality';
 
 import { ApolloTransaction } from '../apollo/Transaction';
 import { CacheSnapshot } from '../CacheSnapshot';

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'apollo-utilities';
+import isEqual from '@wry/equality';
 
 import { CacheContext } from '../context';
 import { InvalidPayloadError, OperationError } from '../errors';

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -1,23 +1,21 @@
-import { valueFromNode, FragmentMap } from 'apollo-utilities';
 // We only depend on graphql for its types; nothing at runtime.
 import { // eslint-disable-line import/no-extraneous-dependencies
+  ArgumentNode,
   DocumentNode,
-  OperationDefinitionNode,
-  ValueNode,
-  SelectionSetNode,
   FieldNode,
+  OperationDefinitionNode,
+  OperationTypeNode,
+  SelectionNode,
+  SelectionSetNode,
+  ValueNode,
 } from 'graphql';
+import { getOperationDefinition, FragmentMap } from '@apollo/client/utilities';
+import invariant from 'ts-invariant';
 
 import { JsonValue } from '../primitive';
 
 import { isObject } from './primitive';
-
-export {
-  getOperationDefinitionOrDie as getOperationOrDie,
-  variablesInOperation,
-  valueFromNode,
-  FragmentMap,
-} from 'apollo-utilities';
+import { valueFromNode } from './store';
 
 // AST types for convenience.
 export {
@@ -28,8 +26,30 @@ export {
   SelectionNode,
   SelectionSetNode,
   ValueNode,
-  // FieldNode,
-} from 'graphql';
+  FragmentMap,
+};
+
+export function getOperationOrDie(
+  document: DocumentNode,
+): OperationDefinitionNode {
+  const def = getOperationDefinition(document);
+  invariant(def, `GraphQL document is missing an operation`);
+  return def as OperationDefinitionNode;
+}
+
+/**
+ * Returns the names of all variables declared by the operation.
+ */
+export function variablesInOperation(operation: OperationDefinitionNode): Set<string> {
+  const names = new Set<string>();
+  if (operation.variableDefinitions) {
+    for (const definition of operation.variableDefinitions) {
+      names.add(definition.variable.name.value);
+    }
+  }
+
+  return names;
+}
 
 /**
  * Returns the default values of all variables in the operation.

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -2,4 +2,5 @@ export * from './ast';
 export * from './collection';
 export * from './primitive';
 export * from './references';
+export * from './store';
 export * from './tree';

--- a/src/util/references.ts
+++ b/src/util/references.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'apollo-utilities';
+import isEqual from '@wry/equality';
 
 import { NodeReference, NodeSnapshot } from '../nodes';
 import { PathPart } from '../primitive';

--- a/src/util/store.ts
+++ b/src/util/store.ts
@@ -1,0 +1,42 @@
+// We only depend on graphql for its types; nothing at runtime.
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { ValueNode, VariableNode } from 'graphql';
+import { InvariantError } from 'ts-invariant';
+import { VariableValue } from '@apollo/client/utilities';
+
+// Note: These functions were originally a part of apollo-utilities, but were
+// removed 87c7a2bc as they were unused within the apollo-client project.
+
+function defaultValueFromVariable(_node: VariableNode) {
+  throw new InvariantError(`Variable nodes are not supported by valueFromNode`);
+}
+
+/**
+ * Evaluate a ValueNode and yield its value in its natural JS form.
+ */
+export function valueFromNode(
+  node: ValueNode,
+  onVariable: VariableValue = defaultValueFromVariable,
+): any {
+  switch (node.kind) {
+    case 'Variable':
+      return onVariable(node);
+    case 'NullValue':
+      return null;
+    case 'IntValue':
+      return parseInt(node.value);
+    case 'FloatValue':
+      return parseFloat(node.value);
+    case 'ListValue':
+      return node.values.map(v => valueFromNode(v, onVariable));
+    case 'ObjectValue': {
+      const value: { [key: string]: any } = {};
+      for (const field of node.fields) {
+        value[field.name.value] = valueFromNode(field.value, onVariable);
+      }
+      return value;
+    }
+    default:
+      return node.value;
+  }
+}

--- a/test/env/base.ts
+++ b/test/env/base.ts
@@ -1,5 +1,5 @@
-import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 import chaiJestDiff from 'chai-jest-diff';
 
 // Chai

--- a/test/unit/Cache/watchParameterizedFields.ts
+++ b/test/unit/Cache/watchParameterizedFields.ts
@@ -1,6 +1,7 @@
+import { Cache as CacheInterface } from '@apollo/client';
+
 import { query, strictConfig } from '../../helpers';
 import { Cache } from '../../../src';
-import { QueryResult } from '../../../src/operations/read';
 
 describe(`Cache#watch`, () => {
 
@@ -84,7 +85,7 @@ describe(`Cache#watch`, () => {
   });
 
   it(`triggers a callback immediately upon registration`, () => {
-    const updates: QueryResult[] = [];
+    const updates: CacheInterface.DiffResult<any>[] = [];
     cache.watch({ ...simpleGraph, variables: { id: 1 } }, newResult => updates.push(newResult));
 
     expect(updates.length).to.eq(1);
@@ -94,7 +95,7 @@ describe(`Cache#watch`, () => {
   });
 
   it(`triggers a callback after writing the same query with new values`, () => {
-    const updates: QueryResult[] = [];
+    const updates: CacheInterface.DiffResult<any>[] = [];
     cache.watch({ ...simpleGraph, variables: { id: 1 } }, newResult => updates.push(newResult));
     cache.write({ ...simpleGraph, variables: { id: 1 } }, { foo: { id: 1, bar: { id: 3, name: 'bar' } } });
 
@@ -106,7 +107,7 @@ describe(`Cache#watch`, () => {
   });
 
   it(`doesn't trigger a callback if unrelated entities change`, () => {
-    const updates: QueryResult[] = [];
+    const updates: CacheInterface.DiffResult<any>[] = [];
     cache.watch({ ...simpleGraph, variables: { id: 1 } }, newResult => updates.push(newResult));
     cache.write({ ...partialOverlap, variables: { id: 1 } }, { foo: { id: 1, baz: { id: 3, name: 'baz2' } } });
 
@@ -114,7 +115,7 @@ describe(`Cache#watch`, () => {
   });
 
   it(`triggers an update on indirect edits to an entity`, () => {
-    const updates: QueryResult[] = [];
+    const updates: CacheInterface.DiffResult<any>[] = [];
     cache.watch({ ...simpleGraph, variables: { id: 1 } }, newResult => updates.push(newResult));
     cache.write(indirectEdit, { thing: { id: 2, name: 'bar2' } });
 
@@ -125,7 +126,7 @@ describe(`Cache#watch`, () => {
   });
 
   it(`triggers an update on reference updates from the query root`, () => {
-    const updates: QueryResult[] = [];
+    const updates: CacheInterface.DiffResult<any>[] = [];
     cache.watch({ ...simpleGraph, variables: { id: 1 } }, newResult => updates.push(newResult));
     cache.write({ ...simpleGraph, variables: { id: 1 } }, { foo: { id: 100, bar: { id: 2, name: 'bar' } } });
 
@@ -136,7 +137,7 @@ describe(`Cache#watch`, () => {
   });
 
   it(`ignores updates to nodes with different parameters`, () => {
-    const updates: QueryResult[] = [];
+    const updates: CacheInterface.DiffResult<any>[] = [];
     cache.watch({ ...simpleGraph, variables: { id: 1 } }, newResult => updates.push(newResult));
     cache.write({ ...simpleGraph, variables: { id: 100 } }, { foo: { id: 100, bar: { id: 2, name: 'bar' } } });
 
@@ -144,7 +145,7 @@ describe(`Cache#watch`, () => {
   });
 
   it(`ignores updates to parameterized subfields with different parameters`, () => {
-    const updates: QueryResult[] = [];
+    const updates: CacheInterface.DiffResult<any>[] = [];
     cache.watch({ ...simpleGraph, variables: { id: 1 } }, newResult => updates.push(newResult));
     cache.write(
       { ...simpleGraphDifferentParameter, variables: { id: 1 } },
@@ -155,7 +156,7 @@ describe(`Cache#watch`, () => {
   });
 
   it(`handles cases where we transition from complete to incomplete`, () => {
-    const updates: QueryResult[] = [];
+    const updates: CacheInterface.DiffResult<any>[] = [];
     cache.watch({ ...simpleGraph, variables: { id: 1 } }, newResult => updates.push(newResult));
     cache.write({ ...partialOverlap, variables: { id: 1 } }, { foo: { id: 100, baz: { id: 3, name: 'baz' } } });
 

--- a/test/unit/Cache/watchStaticFields.ts
+++ b/test/unit/Cache/watchStaticFields.ts
@@ -1,6 +1,7 @@
+import { Cache as CacheInterface } from '@apollo/client';
+
 import { query, strictConfig } from '../../helpers';
 import { Cache } from '../../../src';
-import { QueryResult } from '../../../src/operations/read';
 
 describe(`Cache#watch`, () => {
 
@@ -66,7 +67,7 @@ describe(`Cache#watch`, () => {
   });
 
   it(`triggers a callback immediately upon registration`, () => {
-    const updates: QueryResult[] = [];
+    const updates: CacheInterface.DiffResult<any>[] = [];
     cache.watch(simpleGraph, newResult => updates.push(newResult));
 
     expect(updates.length).to.eq(1);
@@ -76,7 +77,7 @@ describe(`Cache#watch`, () => {
   });
 
   it(`triggers a callback after writing the same query with new values`, () => {
-    const updates: QueryResult[] = [];
+    const updates: CacheInterface.DiffResult<any>[] = [];
     cache.watch(simpleGraph, newResult => updates.push(newResult));
     cache.write(simpleGraph, { foo: { id: 1, bar: { id: 3, name: 'bar' } } });
 
@@ -88,7 +89,7 @@ describe(`Cache#watch`, () => {
   });
 
   it(`doesn't trigger a callback if unrelated entities change`, () => {
-    const updates: QueryResult[] = [];
+    const updates: CacheInterface.DiffResult<any>[] = [];
     cache.watch(simpleGraph, newResult => updates.push(newResult));
     cache.write(partialOverlap, { foo: { id: 1, baz: { id: 3, name: 'baz2' } } });
 
@@ -96,7 +97,7 @@ describe(`Cache#watch`, () => {
   });
 
   it(`triggers an update on indirect edits to an entity`, () => {
-    const updates: QueryResult[] = [];
+    const updates: CacheInterface.DiffResult<any>[] = [];
     cache.watch(simpleGraph, newResult => updates.push(newResult));
     cache.write(indirectEdit, { thing: { id: 2, name: 'bar2' } });
 
@@ -107,7 +108,7 @@ describe(`Cache#watch`, () => {
   });
 
   it(`triggers an update on reference updates from the query root`, () => {
-    const updates: QueryResult[] = [];
+    const updates: CacheInterface.DiffResult<any>[] = [];
     cache.watch(simpleGraph, newResult => updates.push(newResult));
     cache.write(simpleGraph, { foo: { id: 100, bar: { id: 2, name: 'bar' } } });
 
@@ -118,7 +119,7 @@ describe(`Cache#watch`, () => {
   });
 
   it(`handles transitions from complete to incomplete`, () => {
-    const updates: QueryResult[] = [];
+    const updates: CacheInterface.DiffResult<any>[] = [];
     cache.watch(simpleGraph, newResult => updates.push(newResult));
     cache.write(partialOverlap, { foo: { id: 100, baz: { id: 3, name: 'baz' } } });
 
@@ -130,7 +131,7 @@ describe(`Cache#watch`, () => {
   });
 
   it(`handles transitions from incomplete to complete`, () => {
-    const updates: QueryResult[] = [];
+    const updates: CacheInterface.DiffResult<any>[] = [];
     const cache2 = new Cache(strictConfig);
     cache2.write(partialOverlap, { foo: { id: 1, baz: { id: 3, name: 'baz' } } });
     cache2.watch(simpleGraph, newResult => updates.push(newResult));

--- a/test/unit/context/CacheContext/entityTransformation.ts
+++ b/test/unit/context/CacheContext/entityTransformation.ts
@@ -1,4 +1,4 @@
-import { addTypenameToDocument } from 'apollo-utilities';
+import { addTypenameToDocument } from '@apollo/client/utilities';
 import * as _ from 'lodash';
 
 import { CacheContext } from '../../../../src/context';

--- a/test/unit/context/CacheContext/entityUpdaterOptimisticChange.ts
+++ b/test/unit/context/CacheContext/entityUpdaterOptimisticChange.ts
@@ -23,6 +23,7 @@ describe(`context.CacheContext`, () => {
 
         const userId = user ? user.id : previous.id;
         const { activeUsers } = dataProxy.readQuery({ query: activeUsersQuery.document });
+
         let newActiveUsers: any[];
         if (!nextActive) {
           // Remove users once they're no longer active.

--- a/test/unit/util/ast/selectionSetIsStatic.ts
+++ b/test/unit/util/ast/selectionSetIsStatic.ts
@@ -5,7 +5,11 @@ import { selectionSetIsStatic } from '../../../../src';
 describe(`ast.selectionSetIsStatic`, () => {
 
   function selection(source: string) {
-    return gql(source).definitions[0].selectionSet;
+    const definition = gql(source).definitions[0];
+    if ('selectionSet' in definition) {
+      return definition.selectionSet;
+    }
+    throw new Error(`No selectionSet found in '${source}'`);
   }
 
   it(`considers truly static fragments as static`, () => {
@@ -122,7 +126,5 @@ describe(`ast.selectionSetIsStatic`, () => {
         }
       }`), fragmentGetter)).to.eq(false);
     });
-
   });
-
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     ],
     "module": "commonjs",
     "moduleResolution": "node",
+    "esModuleInterop": true,
     "newLine": "LF",
     "noImplicitAny": true,
     "noImplicitReturns": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,24 @@
 # yarn lockfile v1
 
 
+"@apollo/client@^3.1.2":
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/@apollo/client/-/client-3.1.2.tgz#e384f691706c46aef4d9234b63a03ccc06e9c33c"
+  integrity sha512-GaA/J0CDSSNe0HVm1abeOIJA3M4fs9Ih7wF2z1AI2SLqv5TBLvwBxh0+0+jCSntPZ3gnDQvR7MHjmXota5V1LQ==
+  dependencies:
+    "@types/zen-observable" "^0.8.0"
+    "@wry/context" "^0.5.2"
+    "@wry/equality" "^0.2.0"
+    fast-json-stable-stringify "^2.0.0"
+    graphql-tag "^2.11.0"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.12.1"
+    prop-types "^15.7.2"
+    symbol-observable "^1.2.0"
+    ts-invariant "^0.4.4"
+    tslib "^1.10.0"
+    zen-observable "^0.8.14"
+
 "@babel/code-frame@^7.0.0-beta.35":
   version "7.0.0-beta.40"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz#37e2b0cf7c56026b4b21d3927cadf81adec32ac6"
@@ -35,11 +53,6 @@
   resolved "https://registry.yarnpkg.com/@types/deep-freeze-strict/-/deep-freeze-strict-1.1.0.tgz#447a6a2576191344aa42310131dd3df5c41492c4"
   integrity sha1-RHpqJXYZE0SqQjEBMd099cQUksQ=
 
-"@types/graphql@^0.12.4":
-  version "0.12.4"
-  resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-0.12.4.tgz#d43bb55d45c6de0178bbd11dd59d04fd42138d94"
-  integrity sha512-zICCZ+LEeqAx/mJ2gmMChlIHiUHhsMfy050DXQ5tSR8+GS4Os0Q0vjK9KT3HVV6bXrV60t02e/3dOmnHUcibYw==
-
 "@types/lodash.findindex@^4.6.3":
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/@types/lodash.findindex/-/lodash.findindex-4.6.3.tgz#d73d1b648ff2e1e5198f3360949dd44b595bc93a"
@@ -66,10 +79,42 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.102.tgz#586a3e22385fc79b07cef9c5a1c8a5387986fbc8"
   integrity sha512-k/SxycYmVc6sYo6kzm8cABHcbMs9MXn6jYsja1hLvZ/x9e31VHRRn+1UzWdpv6doVchphvKaOsZ0VTqbF7zvNg==
 
-"@types/node@^8.9.4":
-  version "8.9.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.9.4.tgz#dfd327582a06c114eb6e0441fa3d6fab35edad48"
-  integrity sha512-dSvD36qnQs78G1BPsrZFdPpvLgMW/dnvr5+nTW2csMs5TiP9MOXrjUbnMZOEwnIuBklXtn7b6TPA2Cuq07bDHA==
+"@types/node@^14.0.27":
+  version "14.0.27"
+  resolved "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
+  integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
+
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react@^16.9.44":
+  version "16.9.44"
+  resolved "https://registry.npmjs.org/@types/react/-/react-16.9.44.tgz#da84b179c031aef67dc92c33bd3401f1da2fa3bc"
+  integrity sha512-BtLoJrXdW8DVZauKP+bY4Kmiq7ubcJq+H/aCpRfvPF7RAT3RwR73Sg8szdc2YasbAlWBDrQ6Q+AFM0KwtQY+WQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/zen-observable@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
+  integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
+
+"@wry/context@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.npmjs.org/@wry/context/-/context-0.5.2.tgz#f2a5d5ab9227343aa74c81e06533c1ef84598ec7"
+  integrity sha512-B/JLuRZ/vbEKHRUiGj6xiMojST1kHhu4WcreLfNN7q9DqQFrb97cWgf/kiYsPSUCAMVN0HzfFc8XjJdzgZzfjw==
+  dependencies:
+    tslib "^1.9.3"
+
+"@wry/equality@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/@wry/equality/-/equality-0.2.0.tgz#a312d1b6a682d0909904c2bcd355b02303104fb7"
+  integrity sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==
+  dependencies:
+    tslib "^1.9.3"
 
 JSONStream@^1.3.5:
   version "1.3.5"
@@ -216,20 +261,6 @@ anymatch@^1.3.0:
   dependencies:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
-
-apollo-cache@^1.0.0:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.1.12.tgz#070015c9051b2ebb69676beb10466a9c0b259f91"
-  integrity sha512-D0BPiHvJ6vIrXRh6P4mwlxuUOvODGuJxJq+zIjP8fADIqwjYtH3U3d/PY8dQ2fn4bDbvIAWBUkADBuJLpLIIpg==
-  dependencies:
-    apollo-utilities "^1.0.16"
-
-apollo-utilities@^1.0.0, apollo-utilities@^1.0.16:
-  version "1.0.16"
-  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.16.tgz#787310df4c3900a68c0beb3d351c59725a588cdb"
-  integrity sha512-5oKnElKqkV920KRbitiyISLeG63tUGAyNdotg58bQSX9Omr+smoNDTIRMRLbyIdKOYLaw3LpDaRepOPqljj0NQ==
-  dependencies:
-    fast-json-stable-stringify "^2.0.0"
 
 append-transform@^1.0.0:
   version "1.0.0"
@@ -561,6 +592,11 @@ babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
   integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
+
+backo2@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
+  integrity sha1-MasayLEpNjRj41s+u2n038+6eUc=
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -999,6 +1035,11 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   integrity sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=
   dependencies:
     cssom "0.3.x"
+
+csstype@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/csstype/-/csstype-3.0.2.tgz#ee5ff8f208c8cd613b389f7b222c9801ca62b3f7"
+  integrity sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -1456,6 +1497,11 @@ event-stream@4.0.1:
     stream-combiner "^0.2.2"
     through "^2.3.8"
 
+eventemitter3@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
+
 exec-sh@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.1.tgz#163b98a6e89e6b65b47c2a28d215bc1f63989c38"
@@ -1902,17 +1948,15 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
-graphql-tag@^2.6.0:
-  version "2.7.3"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.7.3.tgz#5040112a1b4623285ef017c252276f0dea37f03f"
-  integrity sha1-UEARKhtGIyhe8BfCUidvDeo38D8=
+graphql-tag@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz#1deb53a01c46a7eb401d6cb59dec86fa1cccbffd"
+  integrity sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==
 
-graphql@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.1.tgz#9b3db3d8e40d1827e4172404bfdd2e4e17a58b55"
-  integrity sha512-awNp3LTrQ7dJDSX3p3PBuxNDC+WFSOrWeV6+l4Xeh2PQJVOFyQ9SZPonXRz2WZc7aIxLZsf2nDZuuuc0qyEq/A==
-  dependencies:
-    iterall "^1.2.0"
+graphql@^15.3.0:
+  version "15.3.0"
+  resolved "https://registry.npmjs.org/graphql/-/graphql-15.3.0.tgz#3ad2b0caab0d110e3be4a5a9b2aa281e362b5278"
+  integrity sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -2050,6 +2094,13 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
   integrity sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==
+
+hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -2521,10 +2572,10 @@ istanbul-reports@^1.3.0:
   dependencies:
     handlebars "^4.0.3"
 
-iterall@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.0.tgz#434e9f41f0b99911ab9c3d49d95f0e079176a2a2"
-  integrity sha512-FB8k5B8otDib0rFysEP5G/oOY6aBF48Y9crLxyZ43eHsk/SfMVH1JqvzU0badSu/WR5nkk3ihp8VQlyBP3SJxg==
+iterall@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
+  integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
 
 jest-changed-files@^23.2.0:
   version "23.2.0"
@@ -2869,6 +2920,11 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
 js-yaml@^3.11.0, js-yaml@^3.9.1:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
@@ -3123,6 +3179,13 @@ loose-envify@^1.0.0:
   integrity sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=
   dependencies:
     js-tokens "^3.0.0"
+
+loose-envify@^1.1.0, loose-envify@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
 
 lru-cache@^4.0.1:
   version "4.1.1"
@@ -3424,9 +3487,9 @@ oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
   integrity sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-copy@^0.1.0:
@@ -3486,6 +3549,13 @@ onetime@^2.0.0:
   integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   dependencies:
     mimic-fn "^1.0.0"
+
+optimism@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.npmjs.org/optimism/-/optimism-0.12.1.tgz#933f9467b9aef0e601655adb9638f893e486ad02"
+  integrity sha512-t8I7HM1dw0SECitBYAqFOVHoBAHEQBTeKjIL9y9ImHzAVkdyPK4ifTgM4VJRDtTUY4r/u5Eqxs4XcGPHaoPkeQ==
+  dependencies:
+    "@wry/context" "^0.5.2"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -3788,6 +3858,15 @@ prompts@^0.1.9:
     clorox "^1.0.1"
     sisteransi "^0.1.0"
 
+prop-types@^15.6.2, prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -3838,6 +3917,20 @@ rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-is@^16.7.0, react-is@^16.8.1:
+  version "16.13.1"
+  resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react@^16.13.1:
+  version "16.13.1"
+  resolved "https://registry.npmjs.org/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
+  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -4522,6 +4615,17 @@ strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
+subscriptions-transport-ws@^0.9.17:
+  version "0.9.17"
+  resolved "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.17.tgz#e30e40f0caae0d2781903c01a8cb51b6e2682098"
+  integrity sha512-hNHi2N80PBz4T0V0QhnnsMGvG3XDFDS9mS6BhZ3R12T6EBywC8d/uJscsga0cVO4DKtXCkCRrWm2sOYrbOdhEA==
+  dependencies:
+    backo2 "^1.0.2"
+    eventemitter3 "^3.1.0"
+    iterall "^1.2.1"
+    symbol-observable "^1.0.4"
+    ws "^5.2.0"
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -4545,6 +4649,11 @@ symbol-observable@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
   integrity sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=
+
+symbol-observable@^1.0.4, symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.2:
   version "3.2.2"
@@ -4685,10 +4794,22 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-tslib@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
-  integrity sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==
+ts-invariant@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
+  integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
+  dependencies:
+    tslib "^1.9.3"
+
+tslib@^1.10.0, tslib@^1.9.3:
+  version "1.13.0"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
+  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
+  integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -4735,10 +4856,10 @@ typescript-estree@2.1.0:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript@~2.8.0:
-  version "2.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
-  integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
+typescript@^3.9.7:
+  version "3.9.7"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 uglify-js@^2.6:
   version "2.8.29"
@@ -4962,6 +5083,13 @@ ws@^4.0.0:
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
+ws@^5.2.0:
+  version "5.2.2"
+  resolved "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
+  integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
+  dependencies:
+    async-limiter "~1.0.0"
+
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
@@ -5047,3 +5175,8 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+zen-observable@^0.8.14:
+  version "0.8.15"
+  resolved "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
+  integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==


### PR DESCRIPTION
The main purpose of this change is to add support for the v3 apollo client. The biggest change affecting Hermes in version 3 is the consolidation of the apollo packages into one `@apollo/client`package. Some utilities from the deprecated `apollo-utilities` package have been removed, and the rest are now accessible via `@apollo/client/utilities`. For the utility methods that were removed, I copied the original implementations from `apollo-utilities` into Hermes. The `isEqual` utility is an exception, as the original implementation was just an alias to `@wry/equality`. For that utility, I just added a dependency to that package. 

There are a couple of changes in particular that I would like careful review:
- ApolloQueryable now *extends* ApolloCache instead of just implementing its interface. The reason I did this was because of all the missing non-abstract methods that exist now on ApolloCache (i.e. `gc`, `identify`, etc). These methods all have simple, almost no-op, implementations and it didn't seem right to copy them all into ApolloQueryable.
- I've updated Typescript to `@latest`, but I wonder if that is too far. It's currently at 3.9. I could look to use something lower if there are things in the `.d.ts` files that aren't compatible with older versions.
- The following methods have all been copied from `apollo-utilities` and I put them in places I thought were logical, but I am not super familiar with the project.
  - `valueFromNode`
  - `defaultValueFromVariable`
  - `variablesInOperation`
  - `getOperationDefinitionOrDie`
