### PR TITLE
Use of @apollo/client/core instead of @apollo/client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "apollo-cache-hermes",
-  "version": "0.8.0",
+  "name": "@charllie/apollo-cache-hermes",
+  "version": "0.8.16",
   "description": "A cache implementation for Apollo Client, tuned for performance",
   "license": "Apache-2.0",
-  "repository": "convoyinc/apollo-cache-hermes",
-  "homepage": "https://github.com/convoyinc/apollo-cache-hermes",
-  "bugs": "https://github.com/convoyinc/apollo-cache-hermes/issues",
+  "repository": "charllie/apollo-cache-hermes",
+  "homepage": "https://github.com/charllie/apollo-cache-hermes",
+  "bugs": "https://github.com/charllie/apollo-cache-hermes/issues",
   "keywords": [
     "apollo",
     "apollo-client",

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -1,4 +1,5 @@
 import { Cache as CacheInterface } from '@apollo/client/core';
+
 import { CacheSnapshot } from './CacheSnapshot';
 import { CacheTransaction } from './CacheTransaction';
 import { CacheContext } from './context';
@@ -10,7 +11,6 @@ import { JsonObject } from './primitive';
 import { Queryable } from './Queryable';
 import { ChangeId, NodeId, RawOperation, Serializable } from './schema';
 import { DocumentNode, setsHaveSomeIntersection } from './util';
-
 
 export { MigrationMap };
 export type TransactionCallback = (transaction: CacheTransaction) => void;

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -1,16 +1,16 @@
-import { Cache as CacheInterface } from '@apollo/client';
-
+import { Cache as CacheInterface } from '@apollo/client/core';
 import { CacheSnapshot } from './CacheSnapshot';
 import { CacheTransaction } from './CacheTransaction';
 import { CacheContext } from './context';
 import { GraphSnapshot } from './GraphSnapshot';
-import { extract, MigrationMap, migrate, QueryObserver, prune, read, restore } from './operations';
+import { extract, migrate, MigrationMap, prune, QueryObserver, read, restore } from './operations';
+import { QueryResult } from './operations/read';
 import { OptimisticUpdateQueue } from './OptimisticUpdateQueue';
 import { JsonObject } from './primitive';
 import { Queryable } from './Queryable';
 import { ChangeId, NodeId, RawOperation, Serializable } from './schema';
 import { DocumentNode, setsHaveSomeIntersection } from './util';
-import { QueryResult } from './operations/read';
+
 
 export { MigrationMap };
 export type TransactionCallback = (transaction: CacheTransaction) => void;

--- a/src/apollo/Hermes.ts
+++ b/src/apollo/Hermes.ts
@@ -1,15 +1,15 @@
 import {
-  ApolloCache, Cache as CacheInterface, Transaction
+  ApolloCache, Cache as CacheInterface, Transaction,
 } from '@apollo/client/core';
+
 import { Cache, MigrationMap } from '../Cache';
 import { CacheSnapshot } from '../CacheSnapshot';
 import { CacheContext } from '../context';
 import { GraphSnapshot } from '../GraphSnapshot';
+
 import { ApolloQueryable } from './Queryable';
 import { ApolloTransaction } from './Transaction';
 import { buildRawOperationFromQuery } from './util';
-
-
 
 /**
  * Apollo-specific interface to the cache.

--- a/src/apollo/Hermes.ts
+++ b/src/apollo/Hermes.ts
@@ -1,17 +1,15 @@
 import {
-  Transaction,
-  Cache as CacheInterface,
-  ApolloCache,
-} from '@apollo/client';
-
-import { CacheContext } from '../context';
+  ApolloCache, Cache as CacheInterface, Transaction
+} from '@apollo/client/core';
 import { Cache, MigrationMap } from '../Cache';
 import { CacheSnapshot } from '../CacheSnapshot';
+import { CacheContext } from '../context';
 import { GraphSnapshot } from '../GraphSnapshot';
-
 import { ApolloQueryable } from './Queryable';
 import { ApolloTransaction } from './Transaction';
 import { buildRawOperationFromQuery } from './util';
+
+
 
 /**
  * Apollo-specific interface to the cache.

--- a/src/apollo/Queryable.ts
+++ b/src/apollo/Queryable.ts
@@ -1,12 +1,12 @@
-import { ApolloCache, Cache, DataProxy, Reference, makeReference } from '@apollo/client';
+import { ApolloCache, Cache, DataProxy, makeReference, Reference } from '@apollo/client/core';
 import { removeDirectivesFromDocument } from '@apollo/client/utilities';
-
 import { UnsatisfiedCacheError } from '../errors';
 import { JsonObject } from '../primitive';
 import { Queryable } from '../Queryable';
 import { DocumentNode } from '../util';
+import { buildRawOperationFromFragment, buildRawOperationFromQuery } from './util';
 
-import { buildRawOperationFromQuery, buildRawOperationFromFragment } from './util';
+
 
 /**
  * Apollo-specific interface to the cache.

--- a/src/apollo/Queryable.ts
+++ b/src/apollo/Queryable.ts
@@ -1,12 +1,12 @@
 import { ApolloCache, Cache, DataProxy, makeReference, Reference } from '@apollo/client/core';
 import { removeDirectivesFromDocument } from '@apollo/client/utilities';
+
 import { UnsatisfiedCacheError } from '../errors';
 import { JsonObject } from '../primitive';
 import { Queryable } from '../Queryable';
 import { DocumentNode } from '../util';
+
 import { buildRawOperationFromFragment, buildRawOperationFromQuery } from './util';
-
-
 
 /**
  * Apollo-specific interface to the cache.

--- a/src/apollo/Transaction.ts
+++ b/src/apollo/Transaction.ts
@@ -5,7 +5,7 @@ import { CacheTransaction } from '../CacheTransaction';
 import { GraphSnapshot } from '../GraphSnapshot';
 import { JsonValue, PathPart } from '../primitive';
 import { NodeId } from '../schema';
-import { deepGet, DocumentNode, verboseTypeof } from '../util';
+import { deepGet, DocumentNode, referenceValues, verboseTypeof } from '../util';
 
 import { ApolloQueryable } from './Queryable';
 
@@ -84,7 +84,7 @@ export class ApolloTransaction extends ApolloQueryable<GraphSnapshot> {
       return;
     }
 
-    for (const { id: outboundId, path } of currentContainerNode.outbound) {
+    for (const { id: outboundId, path } of referenceValues(currentContainerNode.outbound)) {
       if (lodashIsEqual(pathToParameterizedField, path)) {
         const fieldArguments = getOriginalFieldArguments(outboundId);
         if (fieldArguments) {

--- a/src/apollo/Transaction.ts
+++ b/src/apollo/Transaction.ts
@@ -1,13 +1,13 @@
 import { Cache, Transaction } from '@apollo/client/core';
+import lodashIsEqual = require('lodash.isequal');
+
 import { CacheTransaction } from '../CacheTransaction';
 import { GraphSnapshot } from '../GraphSnapshot';
 import { JsonValue, PathPart } from '../primitive';
 import { NodeId } from '../schema';
 import { deepGet, DocumentNode, verboseTypeof } from '../util';
+
 import { ApolloQueryable } from './Queryable';
-import lodashIsEqual = require('lodash.isequal');
-
-
 
 function getOriginalFieldArguments(id: NodeId): { [argName: string]: string } | undefined {
   // Split `${containerId}❖${JSON.stringify(path)}❖${JSON.stringify(args)}`

--- a/src/apollo/Transaction.ts
+++ b/src/apollo/Transaction.ts
@@ -1,13 +1,13 @@
-import { Cache, Transaction } from '@apollo/client';
-import lodashIsEqual = require('lodash.isequal');
-
+import { Cache, Transaction } from '@apollo/client/core';
 import { CacheTransaction } from '../CacheTransaction';
 import { GraphSnapshot } from '../GraphSnapshot';
-import { PathPart, JsonValue } from '../primitive';
+import { JsonValue, PathPart } from '../primitive';
 import { NodeId } from '../schema';
-import { DocumentNode, verboseTypeof, deepGet } from '../util';
-
+import { deepGet, DocumentNode, verboseTypeof } from '../util';
 import { ApolloQueryable } from './Queryable';
+import lodashIsEqual = require('lodash.isequal');
+
+
 
 function getOriginalFieldArguments(id: NodeId): { [argName: string]: string } | undefined {
   // Split `${containerId}❖${JSON.stringify(path)}❖${JSON.stringify(args)}`

--- a/src/nodes/EntitySnapshot.ts
+++ b/src/nodes/EntitySnapshot.ts
@@ -1,4 +1,5 @@
 import { JsonObject, NestedArray, NestedObject } from '../primitive';
+import { NodeId } from '../schema';
 
 import { NodeReference, NodeSnapshot } from './NodeSnapshot';
 
@@ -13,12 +14,29 @@ export { NestedArray, NestedObject };
  * parameterized values that may also have been queried for it.
  */
 export class EntitySnapshot implements NodeSnapshot {
+  inbound?: Map<NodeId, NodeReference>;
+  outbound?: Map<NodeId, NodeReference>;
+
   constructor(
     /** A reference to the entity this snapshot is about. */
     public data?: JsonObject,
     /** Other node snapshots that point to this one. */
-    public inbound?: NodeReference[],
+    inbound?: NodeReference[],
     /** The node snapshots that this one points to. */
-    public outbound?: NodeReference[],
-  ) {}
+    outbound?: NodeReference[],
+  ) {
+    if (inbound) {
+      this.inbound = new Map();
+      for (const reference of inbound) {
+        this.inbound.set(reference.id, reference);
+      }
+    }
+
+    if (outbound) {
+      this.outbound = new Map();
+      for (const reference of outbound) {
+        this.outbound.set(reference.id, reference);
+      }
+    }
+  }
 }

--- a/src/nodes/NodeSnapshot.ts
+++ b/src/nodes/NodeSnapshot.ts
@@ -8,9 +8,9 @@ export interface NodeSnapshot {
   /** A reference to the node this snapshot is about. TODO: Remove? */
   data?: JsonValue;
   /** Other node snapshots that point to this one. */
-  inbound?: NodeReference[];
+  inbound?: Map<NodeId, NodeReference>;
   /** The node snapshots that this one points to. */
-  outbound?: NodeReference[];
+  outbound?: Map<NodeId, NodeReference>;
 }
 
 /**

--- a/src/nodes/ParameterizedValueSnapshot.ts
+++ b/src/nodes/ParameterizedValueSnapshot.ts
@@ -1,6 +1,7 @@
 import { JsonValue, NestedArray, NestedObject } from '../primitive';
+import { NodeId } from '../schema';
 
-import { NodeSnapshot, NodeReference } from './NodeSnapshot';
+import { NodeReference, NodeSnapshot } from './NodeSnapshot';
 
 // Until https://github.com/Microsoft/TypeScript/issues/9944
 export { NestedArray, NestedObject };
@@ -14,12 +15,29 @@ export { NestedArray, NestedObject };
  * overlaid on top of the static values of the entity that contains them.
  */
 export class ParameterizedValueSnapshot implements NodeSnapshot {
+  inbound?: Map<NodeId, NodeReference>;
+  outbound?: Map<NodeId, NodeReference>;
+
   constructor(
     /** A reference to the entity this snapshot is about. */
     public data?: JsonValue,
     /** Other node snapshots that point to this one. */
-    public inbound?: NodeReference[],
+    inbound?: NodeReference[],
     /** The node snapshots that this one points to. */
-    public outbound?: NodeReference[],
-  ) {}
+    outbound?: NodeReference[],
+  ) {
+    if (inbound) {
+      this.inbound = new Map();
+      for (const reference of inbound) {
+        this.inbound.set(reference.id, reference);
+      }
+    }
+
+    if (outbound) {
+      this.outbound = new Map();
+      for (const reference of outbound) {
+        this.outbound.set(reference.id, reference);
+      }
+    }
+  }
 }

--- a/src/nodes/clone.ts
+++ b/src/nodes/clone.ts
@@ -1,3 +1,5 @@
+import { referenceValues } from '../util/references';
+
 import { EntitySnapshot } from './EntitySnapshot';
 import { NodeSnapshot } from './NodeSnapshot';
 import { ParameterizedValueSnapshot } from './ParameterizedValueSnapshot';
@@ -7,13 +9,13 @@ import { ParameterizedValueSnapshot } from './ParameterizedValueSnapshot';
  * preserving object shapes.
  */
 export function cloneNodeSnapshot(parent: NodeSnapshot) {
-  const inbound = parent.inbound ? [...parent.inbound] : undefined;
-  const outbound = parent.outbound ? [...parent.outbound] : undefined;
+  const inbound = parent.inbound ? new Map(parent.inbound) : undefined;
+  const outbound = parent.outbound ? new Map(parent.outbound) : undefined;
 
   if (parent instanceof EntitySnapshot) {
-    return new EntitySnapshot(parent.data, inbound, outbound);
+    return new EntitySnapshot(parent.data, referenceValues(inbound), referenceValues(outbound));
   } else if (parent instanceof ParameterizedValueSnapshot) {
-    return new ParameterizedValueSnapshot(parent.data, inbound, outbound);
+    return new ParameterizedValueSnapshot(parent.data, referenceValues(inbound), referenceValues(outbound));
   } else {
     throw new Error(`Unknown node type: ${Object.getPrototypeOf(parent).constructor.name}`);
   }

--- a/src/operations/SnapshotEditor.ts
+++ b/src/operations/SnapshotEditor.ts
@@ -15,6 +15,7 @@ import {
   isNil,
   lazyImmutableDeepSet,
   pathBeginsWith,
+  referenceValues,
   removeNodeReference,
 } from '../util';
 
@@ -382,7 +383,7 @@ export class SnapshotEditor {
   private _removeArrayReferences(referenceEdits: ReferenceEdit[], containerId: NodeId, prefix: PathPart[], afterIndex: number) {
     const container = this._getNodeSnapshot(containerId);
     if (!container || !container.outbound) return;
-    for (const reference of container.outbound) {
+    for (const reference of referenceValues(container.outbound)) {
       if (!pathBeginsWith(reference.path, prefix)) continue;
       const index = reference.path[prefix.length];
       if (typeof index !== 'number') continue;
@@ -496,7 +497,7 @@ export class SnapshotEditor {
       if (!(snapshot instanceof EntitySnapshot)) continue;
       if (!snapshot || !snapshot.inbound) continue;
 
-      for (const { id, path } of snapshot.inbound) {
+      for (const { id, path } of referenceValues(snapshot.inbound)) {
         this._setValue(id, path, snapshot.data, false);
         if (this._rebuiltNodeIds.has(id)) continue;
 
@@ -520,7 +521,7 @@ export class SnapshotEditor {
       this._editedNodeIds.add(nodeId);
 
       if (!node.outbound) continue;
-      for (const { id, path } of node.outbound) {
+      for (const { id, path } of referenceValues(node.outbound)) {
         const reference = this._ensureNewSnapshot(id);
         if (removeNodeReference('inbound', reference, nodeId, path)) {
           queue.push(id);

--- a/src/operations/extract.ts
+++ b/src/operations/extract.ts
@@ -2,8 +2,8 @@ import { CacheContext } from '../context/CacheContext';
 import { GraphSnapshot } from '../GraphSnapshot';
 import { EntitySnapshot, NodeSnapshot, ParameterizedValueSnapshot } from '../nodes';
 import { JsonValue, NestedValue } from '../primitive';
-import { Serializable, isSerializable } from '../schema';
-import { lazyImmutableDeepSet } from '../util';
+import { isSerializable, Serializable } from '../schema';
+import { lazyImmutableDeepSet, referenceValues } from '../util';
 
 /**
  * Create serializable representation of GraphSnapshot.
@@ -35,11 +35,11 @@ export function extract(graphSnapshot: GraphSnapshot, cacheContext: CacheContext
     const serializedEntity: Serializable.NodeSnapshot = { type };
 
     if (outbound) {
-      serializedEntity.outbound = outbound;
+      serializedEntity.outbound = referenceValues(outbound);
     }
 
     if (inbound) {
-      serializedEntity.inbound = inbound;
+      serializedEntity.inbound = referenceValues(inbound);
     }
 
     // Extract data value
@@ -78,7 +78,7 @@ function extractSerializableData(graphSnapshot: GraphSnapshot, nodeSnapshot: Nod
   let extractedData: JsonValue | null = nodeSnapshot.data;
 
   // Set all the outbound path (e.g reference) to undefined.
-  for (const outbound of nodeSnapshot.outbound) {
+  for (const outbound of referenceValues(nodeSnapshot.outbound)) {
     // Only reference to EntitySnapshot is recorded in the data property
     // So we didn't end up set the value to be 'undefined' in the output
     // in every case

--- a/src/operations/migrate.ts
+++ b/src/operations/migrate.ts
@@ -4,9 +4,8 @@ import { EntitySnapshot, ParameterizedValueSnapshot } from '../nodes';
 import { JsonObject, JsonValue, PathPart } from '../primitive';
 import { NodeId } from '../schema';
 import {
-  isObject,
   addNodeReference,
-  deepGet,
+  deepGet, isObject,
 } from '../util';
 
 import { nodeIdForParameterizedValue, NodeSnapshotMap } from './SnapshotEditor';
@@ -76,7 +75,7 @@ function migrateEntity(
       const fieldId = nodeIdForParameterizedValue(id, parameterized.path, parameterized.args);
       // create a parameterized value snapshot if container doesn't know of the
       // parameterized field we expect
-      if (!snapshot.outbound || !snapshot.outbound.find(s =>  s.id === fieldId)) {
+      if (!snapshot.outbound || !snapshot.outbound.has(fieldId)) {
         let newData = parameterized.defaultReturn;
         if (allNodes && parameterized.copyFrom) {
           const { path, args } = parameterized.copyFrom;

--- a/src/operations/restore.ts
+++ b/src/operations/restore.ts
@@ -7,8 +7,8 @@ import { GraphSnapshot, NodeSnapshotMap } from '../GraphSnapshot';
 import { EntitySnapshot, ParameterizedValueSnapshot } from '../nodes';
 import { OptimisticUpdateQueue } from '../OptimisticUpdateQueue';
 import { JsonObject, JsonValue, NestedValue, PathPart } from '../primitive';
-import { Serializable, NodeId } from '../schema';
-import { isNumber, isObject, isScalar } from '../util';
+import { NodeId, Serializable } from '../schema';
+import { isNumber, isObject, isScalar, referenceValues } from '../util';
 
 /**
  * Restore GraphSnapshot from serializable representation.
@@ -77,7 +77,7 @@ function restoreEntityReferences(nodesMap: NodeSnapshotMap, cacheContext: CacheC
       continue;
     }
 
-    for (const { id: referenceId, path } of outbound) {
+    for (const { id: referenceId, path } of referenceValues(outbound)) {
       const referenceNode = nodesMap[referenceId];
       if (referenceNode instanceof EntitySnapshot && data === null) {
         // data is a reference.

--- a/test/unit/Cache/watchParameterizedFields.ts
+++ b/test/unit/Cache/watchParameterizedFields.ts
@@ -1,7 +1,7 @@
 import { Cache as CacheInterface } from '@apollo/client/core';
+
 import { Cache } from '../../../src';
 import { query, strictConfig } from '../../helpers';
-
 
 describe(`Cache#watch`, () => {
 

--- a/test/unit/Cache/watchParameterizedFields.ts
+++ b/test/unit/Cache/watchParameterizedFields.ts
@@ -1,7 +1,7 @@
-import { Cache as CacheInterface } from '@apollo/client';
-
-import { query, strictConfig } from '../../helpers';
+import { Cache as CacheInterface } from '@apollo/client/core';
 import { Cache } from '../../../src';
+import { query, strictConfig } from '../../helpers';
+
 
 describe(`Cache#watch`, () => {
 

--- a/test/unit/Cache/watchStaticFields.ts
+++ b/test/unit/Cache/watchStaticFields.ts
@@ -1,7 +1,7 @@
 import { Cache as CacheInterface } from '@apollo/client/core';
+
 import { Cache } from '../../../src';
 import { query, strictConfig } from '../../helpers';
-
 
 describe(`Cache#watch`, () => {
 

--- a/test/unit/Cache/watchStaticFields.ts
+++ b/test/unit/Cache/watchStaticFields.ts
@@ -1,7 +1,7 @@
-import { Cache as CacheInterface } from '@apollo/client';
-
-import { query, strictConfig } from '../../helpers';
+import { Cache as CacheInterface } from '@apollo/client/core';
 import { Cache } from '../../../src';
+import { query, strictConfig } from '../../helpers';
+
 
 describe(`Cache#watch`, () => {
 


### PR DESCRIPTION
Hello,
I intended to use apollo-cache-hermes in Angular but got some compiling issues such as:
```
node_modules/@apollo/client/react/context/ApolloContext.d.ts:1:19 - error TS2307: Cannot find module 'react' or its corresponding type declarations.
Cannot find module 'react' or its corresponding type declarations.
```

This pull request solves this issue by importing Apollo client classes from ``@apollo/client/core`` instead of ``@apollo/client``.
