### PR TITLE
Make Hermes.restore return Hermes instead of the superclass type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-cache-hermes",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A cache implementation for Apollo Client, tuned for performance",
   "license": "Apache-2.0",
   "repository": "convoyinc/apollo-cache-hermes",

--- a/src/apollo/Hermes.ts
+++ b/src/apollo/Hermes.ts
@@ -1,7 +1,6 @@
 import {
   Transaction,
   Cache as CacheInterface,
-  ApolloCache,
 } from '@apollo/client';
 
 import { CacheContext } from '../context';
@@ -26,7 +25,7 @@ export class Hermes extends ApolloQueryable<GraphSnapshot> {
   }
 
   // TODO (yuisu): data can be typed better with update of ApolloCache API
-  restore(data: any, migrationMap?: MigrationMap, verifyOptions?: CacheInterface.ReadOptions): ApolloCache<GraphSnapshot> {
+  restore(data: any, migrationMap?: MigrationMap, verifyOptions?: CacheInterface.ReadOptions): Hermes {
     const verifyQuery = verifyOptions && buildRawOperationFromQuery(verifyOptions.query, verifyOptions.variables);
     this._queryable.restore(data, migrationMap, verifyQuery);
     return this;


### PR DESCRIPTION
# Summary

`Hermes` extends `ApolloQueryable<GraphSnapshot>` which in turn extends `ApolloCache<GraphSnapshot>` in which the method `restore` is defined as returning `ApolloCache<GraphSnapshot>`. We return `this` in our implementation, and while `Hermes` is a valid `ApolloCache<GraphSnapshot>`, we should be clear that we are returning `Hermes`. This would then let consumers of `Hermes` use `Hermes` specific methods on the result of `hermes.restore(...)`.

# Tests

As this only changes a type no tests are needed.

